### PR TITLE
Fixes bug introduced from the last few merges: in MultiQubit_TimeDoma…

### DIFF
--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -469,7 +469,7 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                         (data - np.min(data))/(np.max(data) - np.min(data))
                 else:
                     rotated_data_dict[qb_name][data_to_fit[qb_name]] = \
-                        a_tools.normalize_data_v3(
+                        a_tools.rotate_and_normalize_data_1ch(
                             data=meas_res_dict[list(meas_res_dict)[0]],
                             cal_zero_points=cal_zero_points,
                             cal_one_points=cal_one_points)


### PR DESCRIPTION
Fixes bug introduced from the last few merges: in MultiQubit_TimeDomain_Analysis rotate_data
it was calling a normalized_data_v3 which was renamed to rotate_and_normalize_data_1ch.

@antsr @nathlacroix @michele-cc 