### PR TITLE
Fixes bug related to doing 2D sweeps with the UHFQC_integration_logging_detector

### DIFF
--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -28,6 +28,8 @@ class Detector_Function(object):
         self.set_kw()
         self.value_names = ['val A', 'val B']
         self.value_units = ['arb. units', 'arb. units']
+        # to be used by MC.get_percdone()
+        self.acq_data_len_scaling = 1
 
     def set_kw(self, **kw):
         '''
@@ -421,8 +423,6 @@ class UHFQC_Base(Hard_Detector):
         self.UHFs = [d.UHFQC for d in self.detectors]
         self.UHF_map = {UHF.name: i
                    for UHF, i in zip(self.UHFs, range(len(self.detectors)))}
-        # to be used by MC.get_percdone()
-        self.acq_data_len_scaling = 1
 
     def poll_data(self):
         if self.AWG is not None:

--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -421,6 +421,8 @@ class UHFQC_Base(Hard_Detector):
         self.UHFs = [d.UHFQC for d in self.detectors]
         self.UHF_map = {UHF.name: i
                    for UHF, i in zip(self.UHFs, range(len(self.detectors)))}
+        # to be used by MC.get_percdone()
+        self.acq_data_len_scaling = 1
 
     def poll_data(self):
         if self.AWG is not None:
@@ -501,6 +503,9 @@ class UHFQC_multi_detector(UHFQC_Base):
                     raise Exception('Not all AWG instances in UHFQC_multi_...  '
                                     'are the same')
                 d.AWG = None
+        # to be used in MC.get_percdone()
+        self.acq_data_len_scaling = \
+            self.detectors[0].acquired_data_len_scaling
 
     def prepare(self, sweep_points):
         for d in self.detectors:
@@ -513,7 +518,6 @@ class UHFQC_multi_detector(UHFQC_Base):
                           for UHF, d in raw_data.items()]
 
         return np.concatenate(processed_data)
-
 
     def finish(self):
         if self.AWG is not None:
@@ -1081,6 +1085,8 @@ class UHFQC_integration_logging_det(UHFQC_Base):
         self.AWG = AWG
         self.integration_length = integration_length
         self.nr_shots = nr_shots
+        # to be used in MC.get_percdone()
+        self.acq_data_len_scaling = self.nr_shots
 
         # 0/1/2 crosstalk supressed /digitized/raw
         res_logging_indices = {'lin_trans': 0, 'digitized': 1, 'raw': 2}

--- a/pycqed/measurement/measurement_control.py
+++ b/pycqed/measurement/measurement_control.py
@@ -154,6 +154,9 @@ class MeasurementControl(Instrument):
         # used for determining data writing indices and soft averages
         self.total_nr_acquired_values = 0
 
+        # used in get_percdone to scale the length of acquired data
+        self.acq_data_len_scaling = self.detector_function.acq_data_len_scaling
+
         # needs to be defined here because of the with statement below
         return_dict = {}
         self.last_sweep_pts = None  # used to prevent resetting same value
@@ -1207,7 +1210,7 @@ class MeasurementControl(Instrument):
         h5d.write_dict_to_hdf5(metadata, entry_point=metadata_group)
 
     def get_percdone(self):
-        percdone = (self.total_nr_acquired_values)/(
+        percdone = self.total_nr_acquired_values/self.acq_data_len_scaling/(
             np.shape(self.get_sweep_points())[0]*self.soft_avg())*100
         return percdone
 


### PR DESCRIPTION
Issue #21 

Proposed solution to fix the inability to do 2D sweep with the UHFQC_integration_logging_detector.

Adds acq_data_len_scaling as an attribute to all UHFQC detector functions.
Divides by acq_data_len_scaling in MC.get_percdone().

Fixes Issue #21 .

@antsr 