### PR TITLE
Enh/close file metadata anav2

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -331,6 +331,10 @@ class BaseDataAnalysis(object):
         from each timestamp in self.timestamps
         and stores it into: self.raw_data_dict
         """
+        if not hasattr(self, 'params_dict'):
+            self.params_dict = OrderedDict()
+        if not hasattr(self, 'numeric_params'):
+            self.numeric_params = []
 
         self.params_dict.update(
             {'sweep_parameter_names': 'sweep_parameter_names',
@@ -355,9 +359,15 @@ class BaseDataAnalysis(object):
                     self.add_measured_data(rd_dict))
             self.raw_data_dict = tuple(temp_dict_list)
 
-        self.metadata = self.raw_data_dict.get('exp_metadata', [])
-        if len(self.metadata) == 0:
-            self.metadata = {}
+        # this is needed because of exp_metadata is not found in
+        # the hdf file, then it is set to raw_data_dict['exp_metadata'] = [] by
+        # the method get_data_from_timestamp_list.
+        # But we need it to be an empty dict.
+        # (exp_metadata will always exist in raw_data_dict becuase it is
+        # hardcoded in self.params_dict above)
+        if len(self.raw_data_dict['exp_metadata']) == 0:
+            self.raw_data_dict['exp_metadata'] = {}
+        self.metadata = self.raw_data_dict['exp_metadata']
 
     def process_data(self):
         """

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -216,6 +216,9 @@ class BaseDataAnalysis(object):
             self.save_figures(close_figs=self.options_dict.get(
                 'close_figs', False))
 
+        if self.options_dict.get('close_file', True):
+            self.data_file.close()
+
     @staticmethod
     def get_hdf_param_value(group, param_name):
         '''
@@ -351,6 +354,10 @@ class BaseDataAnalysis(object):
                 temp_dict_list.append(
                     self.add_measured_data(rd_dict))
             self.raw_data_dict = tuple(temp_dict_list)
+
+        self.metadata = self.raw_data_dict.get('exp_metadata', [])
+        if len(self.metadata) == 0:
+            self.metadata = {}
 
     def process_data(self):
         """

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -1949,9 +1949,6 @@ class StateTomographyAnalysis(ba.BaseDataAnalysis):
         if kwargs.get('auto', True):
             self.run_analysis()
 
-    def extract_data(self):
-        super().extract_data()
-
     def process_data(self):
         tomography_qubits = self.options_dict.get('tomography_qubits', None)
         data, Fs, Omega = self.base_analysis.measurement_operators_and_results(

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -205,9 +205,6 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
 
     def extract_data(self):
         super().extract_data()
-        self.metadata = self.raw_data_dict.get('exp_metadata', [])
-        if len(self.metadata) == 0:
-            self.metadata = {}
 
         self.channel_map = self.get_param_value('channel_map')
         if self.channel_map is None:
@@ -1951,6 +1948,9 @@ class StateTomographyAnalysis(ba.BaseDataAnalysis):
 
         if kwargs.get('auto', True):
             self.run_analysis()
+
+    def extract_data(self):
+        super().extract_data()
 
     def process_data(self):
         tomography_qubits = self.options_dict.get('tomography_qubits', None)


### PR DESCRIPTION
Adds line that closes data file in BaseDataAalaysis of analysis_v2.
Instantiates the "metadata" attribute in the extract_data() method of the BaseDataAnalysis class instead of in the MultiQubit_TimeDomain_Analysis.
Instantiates the attributes "params_dict" and "numeric_params" in BaseDataAnalysis.extract_data() if these do not yet exist. Ensures that we can use BaseDataAnalysis to just extract data.


