### PR TITLE
store git hash and diff in MC settings

### DIFF
--- a/pycqed/measurement/measurement_control.py
+++ b/pycqed/measurement/measurement_control.py
@@ -1189,6 +1189,9 @@ class MeasurementControl(Instrument):
         set_grp.attrs['mode'] = self.mode
         set_grp.attrs['measurement_name'] = self.measurement_name
         set_grp.attrs['live_plot_enabled'] = self.live_plot_enabled()
+        sha1_id, diff = self.get_git_info()
+        set_grp.attrs['git_sha1_id'] = sha1_id
+        set_grp.attrs['git_diff'] = diff
 
     @classmethod
     def save_exp_metadata(self, metadata: dict, data_object):
@@ -1403,9 +1406,9 @@ class MeasurementControl(Instrument):
     # Parameter get/set functions  #
     ################################
 
-    def get_git_hash(self):
-        self.git_hash = general.get_git_revision_hash()
-        return self.git_hash
+    def get_git_info(self):
+        self.git_info = general.get_git_info()
+        return self.git_info
 
     def get_measurement_begintime(self):
         self.begintime = time.time()

--- a/pycqed/utilities/general.py
+++ b/pycqed/utilities/general.py
@@ -24,6 +24,13 @@ digs = string.digits + string.ascii_letters
 
 
 def get_git_info():
+    '''
+    Returns the SHA1 ID (hash) of the current git HEAD plus a diff against the HEAD
+    The hash is shortened to the first 10 digits.
+
+    :return: hash string, diff string
+    '''
+
     diff = "Could not extract diff"
     hash = '00000'
     try:

--- a/pycqed/utilities/general.py
+++ b/pycqed/utilities/general.py
@@ -23,17 +23,19 @@ log = logging.getLogger(__name__)
 digs = string.digits + string.ascii_letters
 
 
-def get_git_revision_hash():
+def get_git_info():
+    diff = "Could not extract diff"
+    hash = '00000'
     try:
         # Refers to the global qc_config
         PycQEDdir = pq.__path__[0]
         hash = subprocess.check_output(['git', 'rev-parse',
                                         '--short=10', 'HEAD'], cwd=PycQEDdir)
+        diff = subprocess.run(['git', '-C', PycQEDdir, "diff"],
+                              stdout=subprocess.PIPE).stdout.decode('utf-8')
     except:
-        logging.warning('Failed to get Git revision hash, using 00000 instead')
-        hash = '00000'
-
-    return hash
+        pass
+    return hash, diff
 
 
 def str_to_bool(s):

--- a/pycqed/utilities/general.py
+++ b/pycqed/utilities/general.py
@@ -24,25 +24,25 @@ digs = string.digits + string.ascii_letters
 
 
 def get_git_info():
-    '''
+    """
     Returns the SHA1 ID (hash) of the current git HEAD plus a diff against the HEAD
     The hash is shortened to the first 10 digits.
 
     :return: hash string, diff string
-    '''
+    """
 
     diff = "Could not extract diff"
-    hash = '00000'
+    githash = '00000'
     try:
         # Refers to the global qc_config
         PycQEDdir = pq.__path__[0]
-        hash = subprocess.check_output(['git', 'rev-parse',
-                                        '--short=10', 'HEAD'], cwd=PycQEDdir)
+        githash = subprocess.check_output(['git', 'rev-parse',
+                                           '--short=10', 'HEAD'], cwd=PycQEDdir)
         diff = subprocess.run(['git', '-C', PycQEDdir, "diff"],
                               stdout=subprocess.PIPE).stdout.decode('utf-8')
-    except:
+    except Exception:
         pass
-    return hash, diff
+    return githash, diff
 
 
 def str_to_bool(s):


### PR DESCRIPTION
To make the code used for a measurement reproducible, the SHA1 ID of the current HEAD plus a git diff against the HEAD needs to be stored. This is implemented here by @nathlacroix and me.

Changes proposed in this pull request:
- extended get_git_revision_hash() to also retrieve a diff against HEAD and renamed it to get_git_info()
- store the retrieved git SHA1 id and the retrieved in the MC settings section of each measurement HDF file
