### PR TITLE
virtual_AWG8: make awg_nr optional in clock_freq() to avoid a crash …

### DIFF
--- a/pycqed/instrument_drivers/virtual_instruments/virtual_AWG8.py
+++ b/pycqed/instrument_drivers/virtual_instruments/virtual_AWG8.py
@@ -127,7 +127,7 @@ class VirtualAWG8(Instrument):
                     docstring=docst)
                 self._params_to_skip_update.append(parname)
 
-    def clock_freq(self, awg_nr):
+    def clock_freq(self, awg_nr=None):
         return 2.4e9
 
     def upload_codeword_program(self):


### PR DESCRIPTION
…when pulsar calls it without this argument

Just a tiny fix to save trouble with virtual setups that use the virtual_AWG8. In case there is some other part of the code that indeed calls this function with two arguments, this will cause no problems since I kept the second argument as an optional one.

Inviting @antsr to review
FYI @stephlazar @nathlacroix @MichKe95 

