### PR TITLE
Enh/multi refpulse

### DIFF
--- a/pycqed/measurement/waveform_control/block.py
+++ b/pycqed/measurement/waveform_control/block.py
@@ -94,8 +94,11 @@ class Block:
 
             # rename ref pulse within the block if not a special name
             escape_names = ("previous_pulse", "segment_start")
-            if ref_pulse not in escape_names and not p_is_block_start:
-                p['ref_pulse'] = name + "-|-" + p['ref_pulse']
+            if isinstance(ref_pulse, list):
+                p['ref_pulse'] = [name + "-|-" + rp for rp in p['ref_pulse']]
+            else:
+                if ref_pulse not in escape_names and not p_is_block_start:
+                    p['ref_pulse'] = name + "-|-" + p['ref_pulse']
 
         return pulses_built
 

--- a/pycqed/measurement/waveform_control/circuit_builder.py
+++ b/pycqed/measurement/waveform_control/circuit_builder.py
@@ -336,3 +336,18 @@ class CircuitBuilder:
         pulses += self.mux_readout(**ro_kwargs).build()
         seq.add(Segment('Segment1', pulses))
         return seq
+
+    def simultaneous_blocks(self, block_name, blocks):
+        simultaneous = Block(block_name, [])
+        simultaneous_end_pulses = []
+        for block in blocks:
+            simultaneous.extend(block.build(ref_pulse=f"start"))
+            simultaneous_end_pulses.append(simultaneous.pulses[-1]['name'])
+        simultaneous.extend([{"name": f"simultaneous_end_pulse",
+                              "pulse_type": "VirtualPulse",
+                              "pulse_delay": 0,
+                              "ref_pulse": simultaneous_end_pulses,
+                              "ref_point": 'end',
+                              "ref_function": 'max'
+                              }])
+        return simultaneous

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -215,7 +215,8 @@ class Segment:
             for unpulse in visited_pulses:
                 if unpulse not in self.unresolved_pulses:
                     log.error(unpulse)
-            raise Exception('Not all pulses have been resolved!')
+            raise Exception(f'Not all pulses have been resolved: '
+                            f'{self.unresolved_pulses}')
 
         # adds the resolved pulses to the elements OrderedDictionary
         for (t0, i, p) in sorted(visited_pulses):

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -157,26 +157,58 @@ class Segment:
         if len(visited_pulses) == 0:
             raise ValueError('No pulse references to the segment start!')
 
+        ref_pulses_dict_all = deepcopy(ref_pulses_dict)
         # add remaining pulses
         while len(ref_pulses_dict) > 0:
             ref_pulses_dict_new = {}
             for name, pulse in ref_pulses_dict.items():
                 for p in pulses[name]:
+                    if isinstance(p.ref_pulse, list):
+                        if p.pulse_obj.name in [vp[2].pulse_obj.name for vp
+                                                in visited_pulses]:
+                            continue
+                        if any([ref_pulse not in [ref_pulse_name for ref_pulse_name
+                                                  in ref_pulses_dict_all.keys()]
+                                for ref_pulse in p.ref_pulse]):
+                            continue
+
+                        t0_list = []
+                        delay_list = [p.delay] * len(p.ref_pulse) if not isinstance(p.delay, list) else p.delay
+                        ref_point_list = [p.ref_point] * len(p.ref_pulse) if not isinstance(p.ref_point, list) \
+                            else p.ref_point
+
+                        for (ref_pulse, delay, ref_point) in zip(p.ref_pulse, delay_list, ref_point_list):
+                            t0_list.append(ref_pulses_dict_all[ref_pulse].pulse_obj.algorithm_time() + delay -
+                                           p.ref_point_new * p.pulse_obj.length +
+                                           ref_point * pulse.pulse_obj.length)
+
+                        if p.ref_function == 'max':
+                            t0 = max(t0_list)
+                        elif p.ref_function == 'min':
+                            t0 = min(t0_list)
+                        elif p.ref_function == 'mean':
+                            t0 = np.mean(t0_list)
+                        else:
+                            raise ValueError('Passed invalid value for ' +
+                                'ref_function. Allowed values are: max, min, mean.' +
+                                ' Default value: min')
+                    else:
+                        t0 = pulse.pulse_obj.algorithm_time() + p.delay - \
+                            p.ref_point_new * p.pulse_obj.length + \
+                            p.ref_point * pulse.pulse_obj.length
+
+                    p.pulse_obj.algorithm_time(t0)
 
                     # add p.name to reference list if it is used as a key
                     # in pulses
                     if p.pulse_obj.name in pulses:
                         ref_pulses_dict_new.update({p.pulse_obj.name: p})
 
-                    t0 = pulse.pulse_obj.algorithm_time() + p.delay - \
-                        p.ref_point_new * p.pulse_obj.length + \
-                        p.ref_point * pulse.pulse_obj.length
-                    p.pulse_obj.algorithm_time(t0)
-
                     visited_pulses.append((t0, i, p))
                     i += 1
 
             ref_pulses_dict = ref_pulses_dict_new
+            ref_pulses_dict_all.update(ref_pulses_dict_new)
 
         if len(visited_pulses) != len(self.unresolved_pulses):
             log.error(f"{len(visited_pulses), len(self.unresolved_pulses)}")
@@ -341,10 +373,14 @@ class Segment:
 
         pulses = {}
         for pulse in self.unresolved_pulses:
-            if pulse.ref_pulse not in pulses:
-                pulses[pulse.ref_pulse] = [pulse]
-            elif pulse.ref_pulse in pulses:
-                pulses[pulse.ref_pulse].append(pulse)
+            ref_pulse_list = pulse.ref_pulse
+            if not isinstance(ref_pulse_list, list):
+                ref_pulse_list = [ref_pulse_list]
+            for p in ref_pulse_list:
+                if p not in pulses:
+                    pulses[p] = [pulse]
+                else:
+                    pulses[p].append(pulse)
 
         return pulses
 
@@ -1067,6 +1103,7 @@ class UnresolvedPulse:
             raise ValueError('Passed invalid value for ref_point_new. Allowed '
                 'values are: start, end, middle. Default value: start')
 
+        self.ref_function = pulse_pars.get('ref_function', 'max')
         self.delay = pulse_pars.get('pulse_delay', 0)
         self.original_phase = pulse_pars.get('phase', 0)
         self.basis = pulse_pars.get('basis', None)


### PR DESCRIPTION
This adds the possibility to specify multiple reference pulses for a pulse. The property ref_function can then be used to specify how the resulting reference points should be resolved to single point in time (max, min, mean).

The circuit builder is extended by a method simultaneous_blocks that makes use of this feature to properly resolve the timing of simultaneous blocks. An example can be found in examples\new_feature_demos\block_demo.ipynb

The pull request also contains minor code cleanup in segment.py.

Inviting @antsr and @nathlacroix to review.
FYI @stephlazar @MichKe95 
