### PR TITLE
Modified fluxpulse_scope_sequence to allow for longer measurements

### DIFF
--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -3273,7 +3273,7 @@ class QuDev_transmon(Qubit):
                                  analyze=True, cal_points=True,
                                  upload=True, label=None,
                                  n_cal_points_per_state=2, cal_states='auto',
-                                 prep_params=None, exp_metadata=None):
+                                 prep_params=None, exp_metadata=None, **kw):
         '''
         flux pulse scope measurement used to determine the shape of flux pulses
         set up as a 2D measurement (delay and drive pulse frequecy are
@@ -3316,7 +3316,7 @@ class QuDev_transmon(Qubit):
                 delays=delays, freqs=freqs, qb_name=self.name,
                 operation_dict=self.get_operation_dict(),
                 cz_pulse_name=cz_pulse_name, cal_points=cp,
-                prep_params=prep_params, upload=False)
+                prep_params=prep_params, upload=False, **kw)
         MC.set_sweep_function(awg_swf.SegmentHardSweep(
             sequence=seq, upload=upload, parameter_name='Delay', unit='s'))
         MC.set_sweep_points(sweep_points)

--- a/pycqed/measurement/pulse_sequences/fluxing_sequences.py
+++ b/pycqed/measurement/pulse_sequences/fluxing_sequences.py
@@ -337,8 +337,8 @@ def chevron_seqs(qbc_name, qbt_name, qbr_name, hard_sweep_dict, soft_sweep_dict,
 
 
 def fluxpulse_scope_sequence(
-              delays, freqs, qb_name, operation_dict, cz_pulse_name,
-              cal_points=None, prep_params=None, upload=True):
+        delays, freqs, qb_name, operation_dict, cz_pulse_name,
+        ro_pulse_delay=100e-9, cal_points=None, prep_params=None, upload=True):
     '''
     Performs X180 pulse on top of a fluxpulse
 
@@ -366,7 +366,7 @@ def fluxpulse_scope_sequence(
     ro_pulse['name'] = 'FPS_Ro'
     ro_pulse['ref_pulse'] = 'FPS_Pi'
     ro_pulse['ref_point'] = 'end'
-    ro_pulse['pulse_delay'] = 100e-9
+    ro_pulse['pulse_delay'] = ro_pulse_delay
 
     pulses = [ge_pulse, flux_pulse, ro_pulse]
     swept_pulses = sweep_pulse_params(pulses,

--- a/pycqed/measurement/pulse_sequences/fluxing_sequences.py
+++ b/pycqed/measurement/pulse_sequences/fluxing_sequences.py
@@ -338,7 +338,7 @@ def chevron_seqs(qbc_name, qbt_name, qbr_name, hard_sweep_dict, soft_sweep_dict,
 
 def fluxpulse_scope_sequence(
               delays, freqs, qb_name, operation_dict, cz_pulse_name,
-              cal_points=None, prep_params=dict(), upload=True):
+              cal_points=None, prep_params=None, upload=True):
     '''
     Performs X180 pulse on top of a fluxpulse
 
@@ -348,6 +348,9 @@ def fluxpulse_scope_sequence(
        |        ---      | --------- fluxpulse ---------- |
                          <-  delay  ->
     '''
+    if prep_params is None:
+        prep_params = {}
+
     seq_name = 'Fluxpulse_scope_sequence'
     ge_pulse = deepcopy(operation_dict['X180 ' + qb_name])
     ge_pulse['name'] = 'FPS_Pi'

--- a/pycqed/measurement/pulse_sequences/fluxing_sequences.py
+++ b/pycqed/measurement/pulse_sequences/fluxing_sequences.py
@@ -365,9 +365,8 @@ def fluxpulse_scope_sequence(
     ro_pulse = deepcopy(operation_dict['RO ' + qb_name])
     ro_pulse['name'] = 'FPS_Ro'
     ro_pulse['ref_pulse'] = 'FPS_Pi'
-    ro_pulse['ref_point'] = 'middle'
-    ro_pulse['pulse_delay'] = flux_pulse['pulse_length'] - np.min(delays) + \
-                              flux_pulse.get('buffer_length_end', 0)
+    ro_pulse['ref_point'] = 'end'
+    ro_pulse['pulse_delay'] = 100e-9
 
     pulses = [ge_pulse, flux_pulse, ro_pulse]
     swept_pulses = sweep_pulse_params(pulses,


### PR DESCRIPTION
A change by @christiankraglundandersen tested successfully during QAOA  experiments with @nathlacroix and @chellings and during measurements by @PAMouny 

Previously, the readout started only after the end of the flux pulse. Like this, the possible length of a measurement was T1-limited. By starting the readout already during the flux pulse, we can do flux pulse scope measurements with a pulse length of, e.g., 50us to get a better fit of the longest time constant in the IIR fitting. The change comes at the cost of a slight reduction of the contrast, but the above-mentioned experiments show that this does not impair the filter fitting procedure.

In addition, this pull request fixes the default value for an empty dict in fluxpulse_scope_sequence().

Inviting @stephlazar and @jo3141 to review.
FYI @antsr @MichKe95 