### PR TITLE
bugfix in Segment.resolve_timing: in case of multiple reference pulses…

### DIFF
--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -179,7 +179,7 @@ class Segment:
                         for (ref_pulse, delay, ref_point) in zip(p.ref_pulse, delay_list, ref_point_list):
                             t0_list.append(ref_pulses_dict_all[ref_pulse].pulse_obj.algorithm_time() + delay -
                                            p.ref_point_new * p.pulse_obj.length +
-                                           ref_point * pulse.pulse_obj.length)
+                                           ref_point * ref_pulses_dict_all[ref_pulse].pulse_obj.length)
 
                         if p.ref_function == 'max':
                             t0 = max(t0_list)


### PR DESCRIPTION
… a wrong pulse length was used for calculating the timing

The bug was a copy & paste error from the "else" part (single reference pulse).

This bug did not appear in previous tests, where the multiref feature was only used with virtual pulses (length 0) as ref_pulse.

Maybe @nathlacroix could quickly review this one-line bugfix.
FYI @antsr 