### PR TITLE
Enh/merge sequences

### DIFF
--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -2255,7 +2255,11 @@ def measure_cphase(qbc, qbt, soft_sweep_params, cz_pulse_name,
             cal_points=cp, upload=False, prep_params=prep_params,
             max_flux_length=max_flux_length,
             num_cz_gates=num_cz_gates)
-
+    # compress 2D sweep
+    if kw.get('compress_2D_sweep', False):
+        sequences, hard_sweep_points, soft_sweep_points, cf = \
+            sequences[0].compress_2D_sweep(sequences,
+                                           kw.get("compression_seg_lim", 300))
     hard_sweep_func = awg_swf.SegmentHardSweep(
         sequence=sequences[0], upload=upload,
         parameter_name=list(hard_sweep_params)[0],
@@ -2293,6 +2297,7 @@ def measure_cphase(qbc, qbt, soft_sweep_params, cz_pulse_name,
                               qbt.name: {'g': 0, 'e': 1}} if
                              (len(cal_states) != 0 and not classified) else None,
                          'data_to_fit': {qbc.name: 'pf', qbt.name: 'pe'},
+                         'compression_factor': cf,
                          'hard_sweep_params': hard_sweep_params,
                          'soft_sweep_params': soft_sweep_params})
     MC.run_2D(label, exp_metadata=exp_metadata)

--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -2205,6 +2205,9 @@ def measure_cphase(qbc, qbt, soft_sweep_params, cz_pulse_name,
     Args:
         qbc (QuDev_transmon): control qubit / fluxed qubit
         qbt (QuDev_transmon): target qubit / non-fluxed qubit
+        compression_seg_lim (int): Default: None. If speficied, it activates the
+            compression of a 2D sweep (see Sequence.compress_2D_sweep) with the given
+            limit on the maximal number of segments per sequence.
     '''
     plot_all_traces = kw.get('plot_all_traces', True)
     plot_all_probs = kw.get('plot_all_probs', True)
@@ -2256,10 +2259,10 @@ def measure_cphase(qbc, qbt, soft_sweep_params, cz_pulse_name,
             max_flux_length=max_flux_length,
             num_cz_gates=num_cz_gates)
     # compress 2D sweep
-    if kw.get('compress_2D_sweep', False):
+    if kw.get('compression_seg_lim', None) is not None:
         sequences, hard_sweep_points, soft_sweep_points, cf = \
             sequences[0].compress_2D_sweep(sequences,
-                                           kw.get("compression_seg_lim", 300))
+                                           kw.get("compression_seg_lim"))
     hard_sweep_func = awg_swf.SegmentHardSweep(
         sequence=sequences[0], upload=upload,
         parameter_name=list(hard_sweep_params)[0],

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -1110,6 +1110,17 @@ class Segment:
         output += f'\n% {num_single_qb} single-qubit gates, {num_two_qb} two-qubit gates, {num_virtual} virtual gates'
         return output
 
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        new_seg = cls.__new__(cls)
+        memo[id(self)] = new_seg
+        for k, v in self.__dict__.items():
+            if k == "pulsar": # the reference to pulsar cannot be deepcopied
+                setattr(new_seg, k, v)
+            else:
+                setattr(new_seg, k, deepcopy(v, memo))
+        return new_seg
+
 
 class UnresolvedPulse:
     """

--- a/pycqed/measurement/waveform_control/sequence.py
+++ b/pycqed/measurement/waveform_control/sequence.py
@@ -7,7 +7,9 @@
 import numpy as np
 import pycqed.measurement.waveform_control.pulsar as ps
 from collections import OrderedDict as odict
-
+from copy import deepcopy
+import logging
+log = logging.getLogger(__name__)
 
 class Sequence:
     """
@@ -24,7 +26,7 @@ class Sequence:
 
     def add(self, segment):
         if segment.name in self.segments:
-            raise Exception('Name {} already exisits in the sequence!'.format(
+            raise NameError('Name {} already exisits in the sequence!'.format(
                 segment.name))
         self.segments[segment.name] = segment
 
@@ -99,6 +101,12 @@ class Sequence:
             n_readouts = np.sum(n_readouts)
         return n_readouts
 
+    def n_segments(self):
+        """
+        Gets the number of segments in the sequence.
+        """
+        return len(self.segments)
+
     def repeat(self, pulse_name, operation_dict, pattern,
                pulse_channel_names=('I_channel', 'Q_channel')):
         """
@@ -132,11 +140,129 @@ class Sequence:
         """
         return self.repeat(pulse_name, operation_dict,
                            (self.n_acq_elements(), 1))
+
+
+    @staticmethod
+    def merge(sequences, segment_limit=None, merge_repeat_patterns=True):
+        """
+        Merges a list of sequences. See documentation of Sequence.__add__()
+        for more information on the merge of two sequences.
+        Args:
+            sequences (list): List of sequences to merge
+            segment_limit (int): maximal number of segments in the merged sequence.
+                if the total number of segments is higher, a list of sequences is
+                returned. Default is None (all sequences are merged)
+            merge_repeat_patterns (bool): Merges the readout pattern when
+                 combining the sequences. If the readout pattern already exists, it adds
+                 to the number of repetition of the pattern. Note that this behavior may
+                 not work for all scenarios. In that case the patterns must be updated
+                  manually after the merge and merge_repeat_patterns should be set to
+                  False. Default: True.
+
+
+        Returns: list of merged sequences
+
+        Examples:
+            >>> # No segment_limit
+            >>> seq1 = Sequence('seq1')
+            >>> seq1.extend(segments_of_seq1)  # 10 segments
+            >>> seq2 = Sequence('seq2')
+            >>> seq2.extend(segments_of_seq2) # 15 segments
+            >>> seq_comb = Sequence.merge([seq1, seq2])
+            >>> # returns a list with 1 sequence with 25 segments
+            >>> # i.e. [seq1 + seq2]
+
+            >>> # 20 segments limit
+            >>> seq1 = Sequence('seq1')
+            >>> seq1.extend(segments_of_seq1) # 10 segments
+            >>> seq2 = Sequence('seq2')
+            >>> seq2.extend(segments_of_seq2) # 15 segments
+            >>> seq3 = Sequence('seq3')
+            >>> seq3.extend(segments_of_seq3) # 5 segments
+            >>> seq_comb = Sequence.merge([seq1, seq2, seq3])
+            >>> # returns list of 2 sequences with 10 and 20 segments,
+            >>> # i.e. [seq1, seq2 + seq3]
+
+
+        """
+        if len(sequences) == 0:
+            raise ValueError("merge requires at least one sequence")
+        elif len(sequences) == 1:
+            # special case, return current sequence:
+            return sequences
+        sequences = [deepcopy(s) for s in sequences]
+        merged_seqs = [sequences[0]]
+        if segment_limit is None:
+            segment_limit = np.inf
+
+        segment_counter = sequences[0].n_segments()
+        seg_occurences = [{s: 1 for s in sequences[0].segments}]
+        for seq in sequences[1:]:
+            assert seq.n_segments() <= segment_limit, \
+                f"Sequence {seq.name} has more segments ({seq.n_segments()})" \
+                f" than the segment_limit ({segment_limit}). Cannot merge " \
+                f"without cropping the sequence."
+            # if over segment_limit, add another separate sequence
+            # to merged sequences
+            if merged_seqs[-1].n_segments() + seq.n_segments() > segment_limit:
+                merged_seqs.append(seq)
+                seg_occurences.append({s: 1 for s in seq.segments})
+                segment_counter = seq.n_segments()
+            # otherwise merge sequences
+            else:
+                for seg_name, segment in seq.segments.items():
+                    try:
+                        merged_seqs[-1].add(segment)
+                    except NameError:  # in case segment name exists, create new name
+                        seg_occurences[-1][seg_name] += 1
+                        new_name =seg_name + \
+                                   f"_copy_from_merge_{seg_occurences[-1][seg_name] - 1}"
+                        segment.name = new_name
+                        merged_seqs[-1].add(segment)
+
+                segment_counter += seq.n_segments()
+
+                merged_seqs[-1].name += "+" + seq.name # update name of merged seq
+                if merge_repeat_patterns:
+                    for ch_name, pattern in seq.repeat_patterns.items():
+                        # if channel is already present, update number of
+                        # repetitions
+                        if ch_name in merged_seqs[-1].repeat_patterns:
+                            pattern_prev = \
+                                merged_seqs[-1].repeat_patterns[ch_name]
+                            if pattern_prev[1] != pattern[1]:
+                                raise NotImplementedError(
+                                    "The repeat patterns for channel: {ch_name} do not "
+                                    f"have the same 'outer loop' specification (see "
+                                    f"docstring Sequence.repeat). Repeat patterns cannot "
+                                    f"be merged automatically. Set merge_repeat_patterns "
+                                    f"to False and update the repeat patterns manually.")
+                            pattern_updated = (pattern_prev[0] + pattern[0],
+                                               pattern_prev[1])
+                            merged_seqs[-1].repeat_patterns[ch_name] = pattern_updated
+                        # add repeat pattern
+                        else:
+                            merged_seqs[-1].repeat_patterns.update({ch_name:
+                                                                         pattern})
+
+        return merged_seqs
+
     def __repr__(self):
         string_repr = f"####### {self.name} #######\n"
         for seg_name, seg in self.segments.items():
             string_repr += str(seg) + "\n"
         return string_repr
+    
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        new_seq = cls.__new__(cls)
+        memo[id(self)] = new_seq
+        for k, v in self.__dict__.items():
+            if k == "pulsar": # the reference to pulsar cannot be deepcopied
+                setattr(new_seq, k, v)
+            else:
+                setattr(new_seq, k, deepcopy(v, memo))
+        return new_seq
 
     def plot(self, segments=None, **segment_plot_kwargs):
         """

--- a/pycqed/measurement/waveform_control/sequence.py
+++ b/pycqed/measurement/waveform_control/sequence.py
@@ -265,7 +265,8 @@ class Sequence:
             segment_limit (int): maximal number of segments that can be in a sequence
             merge_repeat_patterns (bool): see docstring of Sequence.merge.
 
-        Returns: list of compressed sequences, new hardsweep points indices,
+        Returns: list of sequences for the compressed 2D sweep,
+            new hardsweep points indices,
             new soft sweeppoints indices, and the compression factor
 
         """
@@ -298,11 +299,11 @@ class Sequence:
                       f'{np.floor(segment_limit / n_seg)} (full compression)')
             break
         seg_lim_eff = factor * n_seg
-        compressed_sequences = Sequence.merge(sequences, seg_lim_eff,
+        compressed_2D_sweep = Sequence.merge(sequences, seg_lim_eff,
                                               merge_repeat_patterns)
-        hard_sp_ind = np.arange(compressed_sequences[0].n_acq_elements())
-        soft_sp_ind = np.arange(len(compressed_sequences))
-        return compressed_sequences, hard_sp_ind, soft_sp_ind, factor
+        hard_sp_ind = np.arange(compressed_2D_sweep[0].n_acq_elements())
+        soft_sp_ind = np.arange(len(compressed_2D_sweep))
+        return compressed_2D_sweep, hard_sp_ind, soft_sp_ind, factor
 
     def __repr__(self):
         string_repr = f"####### {self.name} #######\n"

--- a/pycqed/measurement/waveform_control/sequence.py
+++ b/pycqed/measurement/waveform_control/sequence.py
@@ -266,7 +266,7 @@ class Sequence:
             merge_repeat_patterns (bool): see docstring of Sequence.merge.
 
         Returns: list of compressed sequences, new hardsweep points indices,
-            new soft sweeppoints indices
+            new soft sweeppoints indices, and the compression factor
 
         """
         assert len(np.unique([s.n_segments() for s in sequences])) == 1, \
@@ -302,7 +302,7 @@ class Sequence:
                                               merge_repeat_patterns)
         hard_sp_ind = np.arange(compressed_sequences[0].n_acq_elements())
         soft_sp_ind = np.arange(len(compressed_sequences))
-        return compressed_sequences, hard_sp_ind, soft_sp_ind
+        return compressed_sequences, hard_sp_ind, soft_sp_ind, factor
 
     def __repr__(self):
         string_repr = f"####### {self.name} #######\n"

--- a/pycqed/utilities/math.py
+++ b/pycqed/utilities/math.py
@@ -29,3 +29,13 @@ def gram_schmidt(B):
             Ai = Ai - t * Aj
         B[:, i] = normalize(Ai)
     return B
+
+
+def factors(n):
+    """
+    Returns all factors of n
+    """
+    import functools
+    return list(functools.reduce(list.__add__,
+                                 ([i, n // i] for i in range(1, int(n ** 0.5) + 1)
+                                  if n % i == 0)))


### PR DESCRIPTION
This pull-request addresses #68. It introduces new features to compress 2D sweeps while making most efficient use of the first dimension (Hardware sweep, i.e. sequence uploaded at once on all instruments). 

For instance, it should reduce a great part of the communication overhead when calibrating 2 qb gates and therefore allow for faster 2 qb gates tuneup. Can also be combined with parallel tuneup (not tested). 

Changes proposed in this pull request:
- Sequence.merge(): allows to merge sequences sequentially
- Deepcopy of sequences and segments: E.g. Now `deepcopy(segment)` works by avoiding the copy of the pulsar, which cannot be deepcopied
- Sequence.compress_2D_sweep(): compressed a 2D sweep easily with the list of sequences as input. See mqm.measure_cphase() for an example
- Adds the necessary parameter and reshaping in BaseAnalysis to decompress the data before proceeding to the usual analysis.

Current limitation:
- only works for sequences using the combination of SegmentHardSweep and SegmentSoftSweep for the 2D sweep (not instrument sweep functions).

Warning:
- features were tested separately but the entire measurement has not been tested on a physical setup yet.

Inviting @chellings for review. FYI @antsr @stephlazar  @christiankraglundandersen  


