### PR TITLE
calibration points: added possibility to specify the segment prefix

### DIFF
--- a/pycqed/measurement/calibration_points.py
+++ b/pycqed/measurement/calibration_points.py
@@ -21,6 +21,7 @@ class CalibrationPoints:
         self.pulse_label_map = kwargs.get("pulse_label_map", default_map)
 
     def create_segments(self, operation_dict, pulse_modifs=dict(),
+                        segment_prefix='calibration_',
                         **prep_params):
         segments = []
 
@@ -51,7 +52,7 @@ class CalibrationPoints:
 
             pulse_list += generate_mux_ro_pulse_list(self.qb_names,
                                                      operation_dict)
-            seg = segment.Segment(f'calibration_{i}', pulse_list)
+            seg = segment.Segment(segment_prefix + f'{i}', pulse_list)
             segments.append(seg)
         return segments
 


### PR DESCRIPTION
See the title. This adds an optional parameter to CalibrationPoints.create_segments(). We used it for some measurement on a development branch, but since it is compatible with any existing code, it would not hurt to have it in the master.

Inviting @nathlacroix to review
FYI @stephlazar 
