### PR TITLE
Add MC parameter to skip the actual measurement

### DIFF
--- a/pycqed/measurement/measurement_control.py
+++ b/pycqed/measurement/measurement_control.py
@@ -82,6 +82,10 @@ class MeasurementControl(Instrument):
                            vals=vals.Bool(),
                            parameter_class=ManualParameter,
                            initial_value=True)
+        self.add_parameter('skip_measurement',
+                           vals=vals.Bool(),
+                           parameter_class=ManualParameter,
+                           initial_value=False)
 
         self.add_parameter(
             'cfg_clipping_mode', vals=vals.Bool(),
@@ -166,6 +170,9 @@ class MeasurementControl(Instrument):
         # needs to be defined here because of the with statement below
         return_dict = {}
         self.last_sweep_pts = None  # used to prevent resetting same value
+
+        if self.skip_measurement():
+            return return_dict
 
         with h5d.Data(name=self.get_measurement_name(),
                       datadir=self.datadir()) as self.data_object:


### PR DESCRIPTION
This adds a qcodes parameter skip_measurement to MC. If this parameter is set to True, the actual measurement (including hdf file creation) is skipped. This is useful to debug sequences on virtual setups, but it can also be used on a physical setup to quickly check what would be measured before starting the actual measurement.

When using MC.skip_measurement(True)
- the actual measurement inside MC.run is skipped
- no hdf file is created (neither for instrument settings nor for data)
- you should set analysis=False in the measurement function you call because there will be nothing to analyze
- you can afterwards use seq = MC.sweep_functions[0].sequence (or seqs = MC.sweep_functions[1].sequence_list) to extract the sequence(s) that would have been measured in a 1D sweep (or 2D sweep)

Inviting @MichKe95 to review
FYI @nathlacroix @antsr @stephlazar @grahamnorris 