### PR TITLE
Feature/parallel ssro

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -236,7 +236,6 @@ class BaseDataAnalysis(object):
             return self.options_dict.get(param_name, default_value)
         # multi timestamp with different metadata
         elif isinstance(self.metadata, (list, tuple)) and len(self.metadata) != 0:
-            print(self.metadata)
             return self.options_dict.get(param_name,
                 self.metadata[metadata_index].get(param_name, default_value))
         # base case
@@ -253,7 +252,7 @@ class BaseDataAnalysis(object):
             folder = a_tools.get_folder(timestamp)
             h5mode = self.options_dict.get('h5mode', 'r+')
             h5filepath = a_tools.measurement_filename(folder)
-            data_file = h5py.File(h5filepath, h5mode)
+            self.data_file = h5py.File(h5filepath, h5mode)
             try:
                 if 'timestamp' in raw_data_dict_ts:
                     raw_data_dict_ts['timestamp'] = timestamp
@@ -264,34 +263,34 @@ class BaseDataAnalysis(object):
                         os.path.split(folder)[1][7:]
                 if 'measured_data' in raw_data_dict_ts:
                     raw_data_dict_ts['measured_data'] = \
-                        np.array(data_file['Experimental Data']['Data']).T
+                        np.array(self.data_file['Experimental Data']['Data']).T
 
                 for save_par, file_par in self.params_dict.items():
                     if len(file_par.split('.')) == 1:
                         par_name = file_par.split('.')[0]
-                        for group_name in data_file.keys():
-                            if par_name in list(data_file[group_name].attrs):
+                        for group_name in self.data_file.keys():
+                            if par_name in list(self.data_file[group_name].attrs):
                                 raw_data_dict_ts[save_par] = \
                                     self.get_hdf_param_value(
-                                        data_file[group_name], par_name)
+                                        self.data_file[group_name], par_name)
                     else:
                         group_name = '/'.join(file_par.split('.')[:-1])
                         par_name = file_par.split('.')[-1]
-                        if group_name in data_file:
-                            if par_name in list(data_file[group_name].attrs):
+                        if group_name in self.data_file:
+                            if par_name in list(self.data_file[group_name].attrs):
                                 raw_data_dict_ts[save_par] = \
                                     self.get_hdf_param_value(
-                                        data_file[group_name], par_name)
-                            elif par_name in list(data_file[group_name].keys()):
+                                        self.data_file[group_name], par_name)
+                            elif par_name in list(self.data_file[group_name].keys()):
                                 raw_data_dict_ts[save_par] = \
-                                    read_dict_from_hdf5({}, data_file[
+                                    read_dict_from_hdf5({}, self.data_file[
                                         group_name][par_name])
                     if isinstance(raw_data_dict_ts[save_par], list) and \
                             len(raw_data_dict_ts[save_par]) == 1:
                         raw_data_dict_ts[save_par] = \
                             raw_data_dict_ts[save_par][0]
             except Exception as e:
-                data_file.close()
+                self.data_file.close()
                 raise e
             raw_data_dict.append(raw_data_dict_ts)
 

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -248,8 +248,10 @@ class BaseDataAnalysis(object):
         data_file = h5py.File(h5filepath, h5mode)
 
         try:
-            return self.get_hdf_datafile_param_value(data_file[path_to_group],
-                                                     attribute)
+            value = self.get_hdf_datafile_param_value(data_file[path_to_group],
+                                                      attribute)
+            data_file.close()
+            return value
         except Exception as e:
             data_file.close()
             raise e

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -236,6 +236,7 @@ class BaseDataAnalysis(object):
             return self.options_dict.get(param_name, default_value)
         # multi timestamp with different metadata
         elif isinstance(self.metadata, (list, tuple)) and len(self.metadata) != 0:
+            print(self.metadata)
             return self.options_dict.get(param_name,
                 self.metadata[metadata_index].get(param_name, default_value))
         # base case
@@ -408,12 +409,12 @@ class BaseDataAnalysis(object):
                              rd in self.raw_data_dict]
 
             for i, rd_dict in enumerate(self.raw_data_dict):
+                if len(rd_dict['exp_metadata']) == 0:
+                    self.metadata[i] = {}
                 temp_dict_list.append(
                     self.add_measured_data(
                         rd_dict,
                         self.get_param_value('compression_factor', 1, i)))
-                if len(rd_dict['exp_metadata']) == 0:
-                    rd_dict['exp_metadata'] = {}
             self.raw_data_dict = tuple(temp_dict_list)
 
 

--- a/pycqed/analysis_v2/readout_analysis.py
+++ b/pycqed/analysis_v2/readout_analysis.py
@@ -882,27 +882,7 @@ class Singleshot_Readout_Analysis_Qutrit(ba.BaseDataAnalysis):
         params = dict()
 
         if method == 'ncc':
-            class NCC:
-                def __init__(self, cluster_centers):
-                    """
-                    cluster_centers is a dict of cluster centers
-                    (name as key, n dimensional array as value)
-
-                    """
-                    self.cluster_centers = cluster_centers
-                def predict(self, X):
-                    pred_states = []
-                    for pt in X:
-                        dist = []
-                        for _, cluster_center in self.cluster_centers.items():
-                            dist.append(np.linalg.norm(pt - cluster_center))
-                        dist = np.asarray(dist)
-                        pred_states.append(np.argmin(dist))
-                    pred_states = np.array(pred_states)
-                    return pred_states
-                def predict_proba(self, X):
-                    raise NotImplementedError("Not implemented for NCC")
-            ncc = NCC(self.proc_data_dict['analysis_params']['mu'])
+            ncc = self.NCC(self.proc_data_dict['analysis_params']['mu'])
             pred_states = ncc.predict(X)
             self.clf_ = ncc
             return pred_states, dict()
@@ -1291,6 +1271,7 @@ class Singleshot_Readout_Analysis_Qutrit(ba.BaseDataAnalysis):
             raise ValueError("covariance type: {} is not supported"
                              .format(cov_type))
         return covs
+
     def prepare_plots(self):
         cmap = plt.get_cmap('tab10')
         tab_x = a_tools.truncate_colormap(cmap, 0, len(self.levels)/10)
@@ -1359,6 +1340,28 @@ class Singleshot_Readout_Analysis_Qutrit(ba.BaseDataAnalysis):
             fig_key = 'state_prob_matrix_masked_{}'.format(self.classif_method)
             self.figs[fig_key] = fig
 
+    class NCC:
+        def __init__(self, cluster_centers):
+            """
+            cluster_centers is a dict of cluster centers
+            (name as key, n dimensional array as value)
+
+            """
+            self.cluster_centers = cluster_centers
+
+        def predict(self, X):
+            pred_states = []
+            for pt in X:
+                dist = []
+                for _, cluster_center in self.cluster_centers.items():
+                    dist.append(np.linalg.norm(pt - cluster_center))
+                dist = np.asarray(dist)
+                pred_states.append(np.argmin(dist))
+            pred_states = np.array(pred_states)
+            return pred_states
+
+        def predict_proba(self, X):
+            raise NotImplementedError("Not implemented for NCC")
 
 class MultiQubit_SingleShot_Analysis(ba.BaseDataAnalysis):
     """

--- a/pycqed/analysis_v2/readout_analysis.py
+++ b/pycqed/analysis_v2/readout_analysis.py
@@ -1307,12 +1307,21 @@ class Singleshot_Readout_Analysis_Qutrit(ba.BaseDataAnalysis):
             plt_fn = {0: main_ax.axvline, 1: main_ax.axhline}
             thresholds = self.proc_data_dict['analysis_params'][
                 'classifier_params'].get("thresholds", dict())
+            mapping = self.proc_data_dict['analysis_params'][
+                'classifier_params'].get("mapping", dict())
             for k, thres in thresholds.items():
                 plt_fn[k](thres, linewidth=2,
                           label="threshold i.u. {}: {:.5f}".format(k, thres),
                           color='k', linestyle="--")
                 main_ax.legend(loc=[0.2,-0.62])
 
+            ax_frac = {0: (0.07, 0.1),  # locations for codewords
+                       1: (0.83, 0.1),
+                       2: (0.07, 0.9),
+                       3: (0.83, 0.9)}
+            for cw, state in mapping.items():
+                main_ax.annotate("0b{:02b}".format(cw) + f":{state}",
+                                 ax_frac[cw], xycoords='axes fraction')
             self.figs['{}_classifier_{}'.format(self.classif_method, dk)] = fig
         if show:
             plt.show()

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5917,33 +5917,6 @@ class MultiQutrit_Singleshot_Readout_Analysis(MultiQubit_TimeDomain_Analysis):
         presel_shots_per_qb = dict() # store preselection ro
         means = defaultdict(dict)    # store mean per qb for each ro_ch
         pdd = self.proc_data_dict    # for convenience of notation
-        # for qbn in self.qb_names:
-        #     # shape is (n_shots, 2) i.e. one column for each ro_ch
-        #     qb_shots_all_states = \
-        #         np.asarray(list(
-        #             self.proc_data_dict['meas_results_per_qb'][qbn].values())).T
-        #     for i, qb_state in enumerate(self.cp.get_states(qbn)):
-        #         # store separately shots with different state preparation
-        #         shots_per_qb[qbn][qb_state] = qb_shots_all_states[i::n_states]
-        #         # make 2D array in case only one channel (1D array)
-        #         if len(shots_per_qb[qbn][qb_state].shape) == 1:
-        #             shots_per_qb[qbn][qb_state] = \
-        #                 np.expand_dims(shots_per_qb[qbn][qb_state], axis=-1)
-        #         means[qbn][qb_state] = np.mean(shots_per_qb[qbn][qb_state], axis=0)
-        #     if self.preselection:
-        #         # preselection shots were removed so look at raw data
-        #         # and look at only the first out of every two readouts
-        #         presel_shots_all_states = \
-        #             np.asarray(list(self.proc_data_dict[
-        #                                 'meas_results_per_qb_raw'][qbn].values())).T[::2]
-        #         for i, qb_state in enumerate(self.cp.get_states(qbn)):
-        #             # store separately shots with different state preparation
-        #             presel_shots_per_qb[qbn][qb_state] = \
-        #                 presel_shots_all_states[i::n_states]
-        #             # make 2D array in case only one channel (1D array)
-        #             if len(presel_shots_per_qb[qbn][qb_state].shape) == 1:
-        #                 presel_shots_per_qb[qbn][qb_state] = \
-        #                     np.expand_dims(presel_shots_per_qb[qbn][qb_state], axis=-1)
 
         for qbn in self.qb_names:
             # shape is (n_shots, n_ro_ch) i.e. one column for each ro_ch

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5689,7 +5689,6 @@ class MultiQutrit_Timetrace_Analysis(ba.BaseDataAnalysis):
 
         if auto:
             self.run_analysis()
-            self.data_file.close()
 
     def extract_data(self):
         super().extract_data()

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5674,8 +5674,18 @@ class MultiQutrit_Timetrace_Analysis(ba.BaseDataAnalysis):
                         loss of precision on FPGA if weights are too small
 
         """
-        super().__init__( **kwargs)
+
+        if qb_names is not None:
+            self.params_dict = {}
+            for qbn in qb_names:
+                s = 'Instrument settings.' + qbn
+                for trans_name in ['ge', 'ef']:
+                    self.params_dict[f'ro_mod_freq_' + qbn] = \
+                        s + f'.ro_mod_freq'
+            self.numeric_params = list(self.params_dict)
+
         self.qb_names = qb_names
+        super().__init__( **kwargs)
 
         if auto:
             self.run_analysis()
@@ -5780,8 +5790,10 @@ class MultiQutrit_Timetrace_Analysis(ba.BaseDataAnalysis):
         rdd = self.raw_data_dict
         ana_params = self.proc_data_dict['analysis_params_dict']
         for qbn in self.qb_names:
-            mod_freq = float(self.get_hdf_param_value(
-                self.data_file[f"Instrument settings/{qbn}"], 'ro_mod_freq'))
+            mod_freq = float(
+                rdd[0].get(f'ro_mod_freq_{qbn}',
+                           self.get_hdf_param_value(f"Instrument settings/{qbn}",
+                                                    'ro_mod_freq')))
             tbase = rdd[0]['hard_sweep_points']
             basis_labels = pdd["analysis_params_dict"][
                 'optimal_weights_basis_labels'][qbn]

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -335,6 +335,8 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                 reset_reps = prep_params.get('reset_reps', 1)
                 self.data_filter = lambda x: x[reset_reps::reset_reps+1]
                 self.data_with_reset = True
+            elif "preselection" in prep_params.get('preparation_type', 'wait'):
+                self.data_filter = lambda x: x[1::2]  # filter preselection RO
         if self.data_filter is None:
             self.data_filter = lambda x: x
 
@@ -378,9 +380,9 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                                                          default_value={})
 
         # create projected_data_dict
-        self.data_to_fit = self.get_param_value('data_to_fit')
-        if self.cal_states_rotations is not None \
-            and not self.get_param_value('global_PCA', default_value=False):
+        self.data_to_fit = self.get_param_value('data_to_fit', {})
+        global_PCA = self.get_param_value('global_PCA', default_value=False)
+        if self.cal_states_rotations is not None or global_PCA:
             self.cal_states_analysis()
         else:
             # this assumes data obtained with classifier detector!

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5724,27 +5724,8 @@ class MultiQutrit_Singleshot_Readout_Analysis(MultiQubit_TimeDomain_Analysis):
         params = dict()
 
         if method == 'ncc':
-            class NCC:
-                def __init__(self, cluster_centers):
-                    """
-                    cluster_centers is a dict of cluster centers
-                    (name as key, n dimensional array as value)
-
-                    """
-                    self.cluster_centers = cluster_centers
-                def predict(self, X):
-                    pred_states = []
-                    for pt in X:
-                        dist = []
-                        for _, cluster_center in self.cluster_centers.items():
-                            dist.append(np.linalg.norm(pt - cluster_center))
-                        dist = np.asarray(dist)
-                        pred_states.append(np.argmin(dist))
-                    pred_states = np.array(pred_states)
-                    return pred_states
-                def predict_proba(self, X):
-                    raise NotImplementedError("Not implemented for NCC")
-            ncc = NCC(self.proc_data_dict['analysis_params']['means'][qb_name])
+            ncc = SSROQutrit.NCC(
+                self.proc_data_dict['analysis_params']['means'][qb_name])
             pred_states = ncc.predict(X)
             # self.clf_ = ncc
             return pred_states, dict(), ncc
@@ -5763,11 +5744,10 @@ class MultiQutrit_Singleshot_Readout_Analysis(MultiQubit_TimeDomain_Analysis):
             pred_states = np.argmax(gm.predict_proba(X), axis=1)
 
             params['means_'] = gm.means_
-            params['covariances_'] = gm.covariances_ #covs
+            params['covariances_'] = gm.covariances_
             params['covariance_type'] = gm.covariance_type
             params['weights_'] = gm.weights_
             params['precisions_cholesky_'] = gm.precisions_cholesky_
-            # self.clf_ = gm
             return pred_states, params, gm
 
         elif method == "threshold":
@@ -5777,7 +5757,6 @@ class MultiQutrit_Singleshot_Readout_Analysis(MultiQubit_TimeDomain_Analysis):
             pred_states = tree.predict(X)
             params["thresholds"], params["mapping"] = \
                 self._extract_tree_info(tree, self.cp.get_states(qb_name)[qb_name])
-            # self.clf_ = tree
             if len(params["thresholds"]) == 1:
                 msg = "Best 2 thresholds to separate this data lie on axis {}" \
                     ", most probably because the data is not well separated." \

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5694,6 +5694,10 @@ class MultiQutrit_Singleshot_Readout_Analysis(MultiQubit_TimeDomain_Analysis):
                 pred_presel = self.clf_[qbn].predict(presel_shots_per_qb[qbn])
                 presel_filter = \
                     pred_presel == self.states_info['g']['int']
+                if np.sum(presel_filter) == 0:
+                    log.warning(f"{qbn}: No data left after preselection! "
+                                f"Skipping preselection data & figures.")
+                    continue
                 qb_shots_masked = qb_shots[presel_filter]
                 prep_states = prep_states[presel_filter]
                 pred_states = self.clf_[qbn].predict(qb_shots_masked)
@@ -5844,7 +5848,7 @@ class MultiQutrit_Singleshot_Readout_Analysis(MultiQubit_TimeDomain_Analysis):
                           scale=self.options_dict.get("hist_scale", "linear"),
                           cmap=tab_x)
             data_keys = [k for k in list(pdd.keys()) if
-                            k.startswith("data")]
+                            k.startswith("data") and qbn in pdd[k]]
 
             for dk in data_keys:
                 data = pdd[dk][qbn]

--- a/pycqed/measurement/calibration_points.py
+++ b/pycqed/measurement/calibration_points.py
@@ -21,6 +21,7 @@ class CalibrationPoints:
         self.pulse_label_map = kwargs.get("pulse_label_map", default_map)
 
     def create_segments(self, operation_dict, pulse_modifs=dict(),
+                        segment_prefix='calibration_',
                         **prep_params):
         segments = []
 
@@ -44,14 +45,24 @@ class CalibrationPoints:
                         pulse['name'] = f"{seg_states[j]}_{pulse_name + qbn}_" \
                                         f"{cal_pt_idx}"
                     pulse_list.append(pulse)
+            state_prep_pulse_names = [p['name'] for p in pulse_list]
             pulse_list = add_preparation_pulses(pulse_list,
                                                 operation_dict,
                                                 [qbn for qbn in self.qb_names],
                                                 **prep_params)
 
-            pulse_list += generate_mux_ro_pulse_list(self.qb_names,
+            ro_pulses = generate_mux_ro_pulse_list(self.qb_names,
                                                      operation_dict)
-            seg = segment.Segment(f'calibration_{i}', pulse_list)
+            # reference all readout pulses to all pulses of the pulse list, to ensure
+            # readout happens after the last pulse (e.g. if doing "f" on some qubits
+            # and "e" on others). In the future we could use the circuitBuilder
+            # and Block here
+            [rp.update({'ref_pulse': state_prep_pulse_names, "ref_point":'end'})
+             for rp in ro_pulses]
+
+            pulse_list += ro_pulses
+
+            seg = segment.Segment(segment_prefix + f'{i}', pulse_list)
             segments.append(seg)
         return segments
 

--- a/pycqed/measurement/hdf5_data.py
+++ b/pycqed/measurement/hdf5_data.py
@@ -15,6 +15,7 @@ import time
 import h5py
 import numpy as np
 import logging
+log = logging.getLogger(__name__)
 
 
 class DateTimeGenerator:
@@ -144,12 +145,14 @@ def write_dict_to_hdf5(data_dict: dict, entry_point, overwrite=False):
         # Basic types
         if isinstance(item, (str, float, int, bool, np.number,
                              np.float_, np.int_, np.bool_)):
+            if not hasattr(key, "encode"):
+                key = repr(key)
             try:
                 entry_point.attrs[key] = item
             except Exception as e:
-                print('Exception occurred while writing'
+                log.error(e)
+                log.error('Exception occurred while writing'
                       ' {}:{} of type {}'.format(key, item, type(item)))
-                logging.warning(e)
         elif isinstance(item, np.ndarray):
             try:
                 entry_point.create_dataset(key, data=item)
@@ -217,7 +220,7 @@ def write_dict_to_hdf5(data_dict: dict, entry_point, overwrite=False):
                         ds.attrs['list_type'] = 'str'
                         ds[:] = data
                     else:
-                        logging.warning(
+                        log.warning(
                             'List of type "{}" for "{}":"{}" not '
                             'supported, storing as string'.format(
                                 elt_type, key, item))
@@ -250,7 +253,7 @@ def write_dict_to_hdf5(data_dict: dict, entry_point, overwrite=False):
                 entry_point.attrs[key] = 'NoneType:__emptylist__'
 
         else:
-            logging.warning(
+            log.warning(
                 'Type "{}" for "{}" (key): "{}" (item) at location {} '
                 'not supported, '
                 'storing as string'.format(type(item), key, item,

--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -481,8 +481,6 @@ def measure_ssro(qubits, states=('g', 'e'), n_shots=10000, label=None,
         prep_params['preparation_type'] = "preselection"
     else:
         prep_params['preparation_type'] = "wait"
-    if prep_params['preparation_type'] not in ['preselection', 'wait']:
-        raise NotImplementedError("Active reset not yet supported for this measurement")
 
     # create and set sequence
     if np.ndim(states) == 2: # list of custom states provided

--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -562,7 +562,7 @@ def measure_ssro(qubits, states=('g', 'e'), n_shots=10000, label=None,
                 'analysis_params']['classifier_params'][qb.name]
             if update:
                 qb.acq_classifier_params(classifier_params)
-        return a, seq
+        return a
 
 def find_optimal_weights(qubits, states=('g', 'e'), upload=True,
                          acq_length=4096/1.8e9, exp_metadata=None,
@@ -698,7 +698,6 @@ def find_optimal_weights(qubits, states=('g', 'e'), upload=True,
                                 f"automatically.")
                 qb.acq_weights_basis(a.proc_data_dict['analysis_params_dict'
                     ]['optimal_weights_basis_labels'][qb.name])
-
 
 
 def measure_active_reset(qubits, shots=5000,

--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -443,7 +443,8 @@ def measure_ssro(qubits, states=('g', 'e'), n_shots=10000, label=None,
             in the ith segment. In the latter case, all_state_combinations is ignored.
         n_shots (int): number of shots
         label (str): measurement label
-        preselection (bool): force preselection even if not in preparation params
+        preselection (bool): force preselection even if not in preparation params.
+            If False then prep_param of first qubit is taken.
         all_states_combinations (bool): if False, then all qubits are prepared
             simultaneously in the first state and then read out, then all qubits
             are prepared in the second state, etc. If True, then all combinations

--- a/pycqed/measurement/waveform_control/sequence.py
+++ b/pycqed/measurement/waveform_control/sequence.py
@@ -17,12 +17,19 @@ class Sequence:
     AWGs sequentially.
     """
 
-    def __init__(self, name):
+    def __init__(self, name, segments=()):
+        """
+        Initializes a Sequence object
+        Args:
+            name: Name of the sequence
+            segments (list, tuple): list of segments to add to the sequence
+        """
         self.name = name
         self.pulsar = ps.Pulsar.get_instance()
         self.segments = odict()
         self.awg_sequence = {}
         self.repeat_patterns = {}
+        self.extend(segments)
 
     def add(self, segment):
         if segment.name in self.segments:


### PR DESCRIPTION
Addresses #70.

Changes proposed in this pull request:
- Parallel SSRO calib measurement: **mqm.measure_ssro()**. uses calibration points to create SSRO sequences with an arbitrary number of qubits in parallel. Also more flexible than previous single qubit measurement in terms of which states can be measured. See doc string for more. Basic functionalities tested on BF1.
-  Parallel SSRO calib analysis. Flexible in terms of which qubits to analyze. Note that **90% of analysis is time required to plot and save the figures**.
- Parallel optimal weights calibration: **mqm.find_optimal_weights()**. Can measure an arbitrary number of qubits in parallel as long as they are not on the same UHF. Tested on virtual setup and on single qubit calib on BF1 (all qubits are on same UHF and therefore the multi qubit version cannot be tested)
- parallel optimal weights Analysis: we were waiting for this analysis since 2017 ;). A basic version of it is now implemented in timedomain_analysis. 

Inviting @stephlazar to review. FYI @christiankraglundandersen @chellings @antsr 


