### PR TITLE
Fix default filter to keep all shots

### DIFF
--- a/pycqed/analysis_v2/readout_analysis.py
+++ b/pycqed/analysis_v2/readout_analysis.py
@@ -1594,7 +1594,7 @@ class MultiQubit_SingleShot_Analysis(ba.BaseDataAnalysis):
             filter = filter.reshape((n_readouts, -1), order='F')
         else:
             # keep all shots
-            filter = np.ones((n_readouts, n_shots), dtype=bool)
+            filter = np.ones((n_readouts, n_shots//n_readouts), dtype=bool)
 
         table = np.zeros((n_readouts, len(observables)))
 

--- a/pycqed/analysis_v2/readout_analysis.py
+++ b/pycqed/analysis_v2/readout_analysis.py
@@ -1592,6 +1592,10 @@ class MultiQubit_SingleShot_Analysis(ba.BaseDataAnalysis):
 
         if filter is not None:
             filter = filter.reshape((n_readouts, -1), order='F')
+        else:
+            # keep all shots
+            filter = np.ones((n_readouts, n_shots), dtype=bool)
+
         table = np.zeros((n_readouts, len(observables)))
 
 


### PR DESCRIPTION
Default filter was missing in SSRO analysis when creating the probability table. 

@stephlazar these two lines should fix it. FYI 