### PR TITLE
Fix state-to-integer mapping to allow arbitrary state order

### DIFF
--- a/pycqed/analysis_v2/readout_analysis.py
+++ b/pycqed/analysis_v2/readout_analysis.py
@@ -941,8 +941,8 @@ class Singleshot_Readout_Analysis_Qutrit(ba.BaseDataAnalysis):
 
     @staticmethod
     def fidelity_matrix(prep_states, pred_states, levels=('g', 'e', 'f'),
-                        plot=False, normalize=True):
-        fm = confusion_matrix(prep_states, pred_states)
+                        labels=None, plot=False, normalize=True):
+        fm = confusion_matrix(prep_states, pred_states, labels)
         if plot:
             Singleshot_Readout_Analysis_Qutrit.plot_fidelity_matrix(fm,
                                                                     levels)

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -6167,7 +6167,7 @@ class MultiQutrit_Singleshot_Readout_Analysis(MultiQubit_TimeDomain_Analysis):
     def _get_state_labels_order(states_labels,
                                 order="gefhabcdijklmnopqrtuvwxyz0123456789"):
         try:
-            return np.array([order.index(s) for s in states_labels])
+            return np.argsort([order.index(s) for s in states_labels])
         except Exception as e:
             log.error(f"Could not find order in state_labels:"
                       f"{states_labels}. {e}."


### PR DESCRIPTION
Fixes the wrong assignment of integer labels (0, 1, 2, etc.) in Gaussian mixture when states aren't passed in the standard order. For instance here, states were given as "e", "g" and as a result the classifier outputted 0 for "e" and 1 for "g" (see shaded areas):
![qb1_gmm_classifier_data_20200613_221253](https://user-images.githubusercontent.com/36669429/84591884-23356d80-ae42-11ea-8423-83fe4d378712.png)

After fix: 
![qb1_gmm_classifier_data_20200613_221253](https://user-images.githubusercontent.com/36669429/84591826-c5088a80-ae41-11ea-84c2-93ff3be35841.png)

The issue was:
The Gaussian Mixture model predicts labels using
range(n_gaussian_components), because it is an unsupervised model.
So when a qubit had only two states, e.g. "g" and "f", it would
predict 0 and 1's but prep_state assumed f= 2. This can cause issues
e.g. when states appearing in cal states are not in the default order
"g", "e", "f". Because the init_means passed to the GMM serves as a
guideline to guess which state will have with label output from the
model (since the model is unsupervised, there is no other
straightforward way to tell the model which component should be 0, 1 or
2). If e.g. "f" occurs first in cal_points, then it would be passed as
  the first "init_means" and thus would be predicted as 0.
  To keep flexibility about state labels and allow for states to be
  added later (e.g. "h" state or maybe multiqubit states), I didn't
  create a manual reordering but instead I adapt the mapping according
  to how states occur in cal_points, for each qubit separately.

Inviting @christiankraglundandersen to review.
