### PR TITLE
Hybrid 1D/2D measurements with analysis_v2

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -24,6 +24,7 @@ import lmfit
 import h5py
 from pycqed.measurement.hdf5_data import write_dict_to_hdf5
 from pycqed.measurement.hdf5_data import read_dict_from_hdf5
+from pycqed.measurement.sweep_points import SweepPoints
 from pycqed.measurement.calibration_points import CalibrationPoints
 import copy
 import logging
@@ -330,7 +331,7 @@ class BaseDataAnalysis(object):
 
     @staticmethod
     def add_measured_data(raw_data_dict, compression_factor=1,
-                          sp=None, cp=None):
+                          sweep_points=None, cal_points=None, prep_params=None):
         """
         Formats measured data based on the raw data dictionary and the
         soft and hard sweep points.
@@ -339,24 +340,25 @@ class BaseDataAnalysis(object):
                 "measured_data" key will be added.
             compression_factor: compression factor of soft sweep points
                 into hard sweep points for the measurement (for 2D sweeps only).
-                The data will be reshaped such that it appears without the compression
-                in "measured_data".
+                The data will be reshaped such that it appears without the
+                compression in "measured_data".
                 If given, it assumes that hard_sweep_points (hsp) and
-                soft_sweep_points (ssp) are indices rather than parameter values,
-                which can be decompressed without any additional information needed.
+                soft_sweep_points (ssp) are indices rather than parameter
+                values, which can be decompressed without any additional
+                information needed.
                 e.g. a sequences with 5 hsp and 4 ssp could be compressed with a
-                compression factor of 2, which means that 2 sequences corresponding
-                to 2 ssp would be  compressed into one single sequence with 10 hsp,
-                and the measured sequence would therefore have 10 hsp and 2ssp.
-                For the decompression, the data will be reshaped to
-                (10/2, 2*2) = (5, 4) to correspond to the initial soft/hard sweep point
-                sizes.
-            sp (SweepPoints class instance): containing the sweep points
-                information for the measurement
-            cp (CalibrationPoints class instance): containing the calibration
-                points information for the measurement
+                compression factor of 2, which means that 2 sequences
+                corresponding to 2 ssp would be  compressed into one single
+                sequence with 10 hsp, and the measured sequence would therefore
+                have 10 hsp and 2ssp. For the decompression, the data will be
+                reshaped to (10/2, 2*2) = (5, 4) to correspond to the initial
+                soft/hard sweep point sizes.
+            sweep_points (SweepPoints class instance): containing the
+                sweep points information for the measurement
+            cal_points (CalibrationPoints class instance): containing the
+                calibration points information for the measurement
 
-        Returns:
+        Returns: raw_data_dict with the key measured_data updated.
 
         """
         if 'measured_data' in raw_data_dict and \
@@ -368,34 +370,48 @@ class BaseDataAnalysis(object):
             if not isinstance(value_names, list):
                 value_names = [value_names]
 
-            sweep_points = measured_data[:-len(value_names)]
-            # sp, cp and hybrid_measurement are needed for a hybrid measurement:
-            # conceptually a 2D measurement that was compressed along the
-            # 1st sweep dimension and the measurement was run in 1D mode
-            # (so only 1 column of sweep points in hdf5 file)
-            # CURRENTLY ONLY WORKS WITH SweepPoints OBJECTS
-            if cp is None:
-                cp = CalibrationPoints('qb', states=[])
+            mc_points = measured_data[:-len(value_names)]
+            # sp, num_cal_segments and hybrid_measurement are needed for a
+            # hybrid measurement: conceptually a 2D measurement that was
+            # compressed along the 1st sweep dimension and the measurement was
+            # run in 1D mode (so only 1 column of sweep points in hdf5 file)
+            # CURRENTLY ONLY WORKS WITH SweepPoints CLASS INSTANCES
             hybrid_measurement = False
-            if sweep_points.shape[0] > 1:
-                hsp = np.unique(sweep_points[0])
-                ssp = np.unique(sweep_points[1:])
+            if mc_points.shape[0] > 1:
+                hsp = np.unique(mc_points[0])
+                ssp = np.unique(mc_points[1:])
                 # if needed, decompress the data (assumes hsp and ssp are indices)
                 if compression_factor != 1:
                     hsp = hsp[:int(len(hsp) / compression_factor)]
                     ssp = np.arange(len(ssp) * compression_factor)
                 raw_data_dict['hard_sweep_points'] = hsp
                 raw_data_dict['soft_sweep_points'] = ssp
-            elif sp is not None:
+            elif sweep_points is not None:
+                print('here')
                 # deal with hybrid measurements
-                if sweep_points.shape[0] == 1 and len(sp) > 1:
+                sp = SweepPoints(from_dict_list=sweep_points)
+                print(mc_points.shape[0], len(sp))
+                if mc_points.shape[0] == 1 and len(sp) > 1:
+                    print('here again')
                     hybrid_measurement = True
-                    hsp = np.arange(len(next(iter(sp[0].values()))[0]))
-                    ssp = np.arange(len(next(iter(sp[1].values()))[0]))
+                    if prep_params is None:
+                        prep_params = dict()
+                    # get length of hard sweep points (1st sweep dimension)
+                    len_dim_1_sp = len(sp.get_sweep_params_property('values', 1))
+                    if 'active' in prep_params.get('preparation_type', 'wait'):
+                        reset_reps = prep_params.get('reset_reps', 1)
+                        len_dim_1_sp *= reset_reps+1
+                    elif "preselection" in prep_params.get('preparation_type',
+                                                           'wait'):
+                        len_dim_1_sp *= 2
+                    hsp = np.arange(len_dim_1_sp)
+                    # get length of soft sweep points (2nd sweep dimension)
+                    dim_2_sp = sp.get_sweep_params_property('values', 2)
+                    ssp = np.arange(len(dim_2_sp))
                     raw_data_dict['hard_sweep_points'] = hsp
                     raw_data_dict['soft_sweep_points'] = ssp
             else:
-                raw_data_dict['hard_sweep_points'] = np.unique(sweep_points[0])
+                raw_data_dict['hard_sweep_points'] = np.unique(mc_points[0])
 
             data = measured_data[-len(value_names):]
             if data.shape[0] != len(value_names):
@@ -405,18 +421,22 @@ class BaseDataAnalysis(object):
                     hsl = len(raw_data_dict['hard_sweep_points'])
                     ssl = len(raw_data_dict['soft_sweep_points'])
                     if hybrid_measurement:
+                        idx_dict_1 = next(iter(cal_points.get_indices(
+                            cal_points.qb_names, prep_params).values()))
+                        num_cal_segments = len([i for j in idx_dict_1.values()
+                                                for i in j])
                         # take out CalibrationPoints from the end of each
                         # segment, and reshape the remaining data based on the
                         # hard (1st dimension) and soft (1st dimension)
                         # sweep points
-                        data_no_cp = data[i][:len(data[i])-len(cp.states)]
+                        data_no_cp = data[i][:len(data[i])-num_cal_segments]
                         measured_data = np.reshape(data_no_cp, (ssl, hsl)).T
-                        if len(cp.states) > 0:
+                        if num_cal_segments > 0:
                             # add back ssl number of copies of the cal points
                             # at the end of each soft sweep slice
-                            cal_pts = data[i][-len(cp.states):]
+                            cal_pts = data[i][-num_cal_segments:]
                             cal_pts_arr = np.reshape(np.repeat(cal_pts, ssl),
-                                                     (len(cp.states), ssl))
+                                                     (num_cal_segments, ssl))
                             measured_data = np.concatenate([measured_data,
                                                             cal_pts_arr])
                     else:
@@ -462,12 +482,15 @@ class BaseDataAnalysis(object):
             if len(self.raw_data_dict['exp_metadata']) == 0:
                 self.raw_data_dict['exp_metadata'] = {}
             self.metadata = self.raw_data_dict['exp_metadata']
+            cp = CalibrationPoints.from_string(self.get_param_value(
+                'cal_points', default_value=
+                CalibrationPoints.from_string(repr(CalibrationPoints([], [])))))
             self.raw_data_dict = self.add_measured_data(
                 self.raw_data_dict,
                 self.get_param_value('compression_factor', 1),
                 self.get_param_value('sweep_points'),
-                CalibrationPoints.from_string(
-                    self.get_param_value('cal_points')))
+                cp, self.get_param_value('preparation_params',
+                                         default_value=dict()))
         else:
             temp_dict_list = []
             self.metadata = [rd['exp_metadata'] for

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -387,12 +387,9 @@ class BaseDataAnalysis(object):
                 raw_data_dict['hard_sweep_points'] = hsp
                 raw_data_dict['soft_sweep_points'] = ssp
             elif sweep_points is not None:
-                print('here')
                 # deal with hybrid measurements
                 sp = SweepPoints(from_dict_list=sweep_points)
-                print(mc_points.shape[0], len(sp))
                 if mc_points.shape[0] == 1 and len(sp) > 1:
-                    print('here again')
                     hybrid_measurement = True
                     if prep_params is None:
                         prep_params = dict()

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -19,6 +19,7 @@ import pycqed.analysis_v2.tomography_qudev as tomo
 import re
 from pycqed.analysis.tools.plotting import SI_val_to_msg_str
 from copy import deepcopy
+from pycqed.measurement.sweep_points import SweepPoints
 from pycqed.measurement.calibration_points import CalibrationPoints
 import matplotlib.pyplot as plt
 from pycqed.analysis.three_state_rotation import predict_proba_avg_ro
@@ -234,10 +235,17 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
         if len(self.channel_map) == 0:
             raise ValueError('No qubit RO channels have been found.')
 
+        # creates self.sp
+        self.get_sweep_points()
+
+    def get_sweep_points(self):
+        self.sp = self.get_param_value('sweep_points')
+        if self.sp is not None:
+            self.sp = SweepPoints(from_dict_list=self.sp)
+
     def create_sweep_points_dict(self):
         sweep_points_dict = self.get_param_value('sweep_points_dict')
         hard_sweep_params = self.get_param_value('hard_sweep_params')
-        self.sp = self.get_param_value('sweep_points')
         if sweep_points_dict is not None:
             # assumed to be of the form {qbn1: swpts_array1, qbn2: swpts_array2}
             self.proc_data_dict['sweep_points_dict'] = \
@@ -252,7 +260,8 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
             if self.mospm is None:
                 raise ValueError('Please provide "meas_obj_sweep_points_map."')
             self.proc_data_dict['sweep_points_dict'] = \
-                {qbn: {'sweep_points': self.sp[0][self.mospm[qbn][0]][0]}
+                {qbn: {'sweep_points': self.sp.get_sweep_params_property(
+                    'values', 1, self.mospm[qbn])[0]}
                  for qbn in self.qb_names}
         else:
             self.proc_data_dict['sweep_points_dict'] = \
@@ -843,7 +852,8 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
             sweep_name = self.get_param_value('sweep_name')
             sweep_unit = self.get_param_value('sweep_unit')
             if self.sp is not None:
-                _, xunit, xlabel = next(iter(self.sp[0].values()))
+                _, xunit, xlabel = self.sp.get_sweep_params_description(
+                    param_names=self.mospm[qb_name], dimension=1)[0]
             elif hard_sweep_params is not None:
                 xlabel = list(hard_sweep_params)[0]
                 xunit = list(hard_sweep_params.values())[0][
@@ -871,7 +881,8 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                     for pn, ssp in self.proc_data_dict['sweep_points_2D_dict'][
                             qb_name].items():
                         if self.sp is not None:
-                            yunit = self.sp[1][pn][1]
+                            yunit = self.sp.get_sweep_params_property(
+                                'unit', dimension=2, param_names=pn)
                         self.plot_dicts[f'{plot_name}_{ro_channel}_{pn}'] = {
                             'fig_id': plot_name + '_' + pn,
                             'ax_id': ax_id,
@@ -974,7 +985,8 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
         sweep_name = self.get_param_value('sweep_name')
         sweep_unit = self.get_param_value('sweep_unit')
         if self.sp is not None:
-            _, xunit, xlabel = next(iter(self.sp[0].values()))
+            _, xunit, xlabel = self.sp.get_sweep_params_description(
+                param_names=self.mospm[qb_name], dimension=1)[0]
         elif hard_sweep_params is not None:
             xlabel = list(hard_sweep_params)[0]
             xunit = list(hard_sweep_params.values())[0][
@@ -1001,7 +1013,8 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
             for pn, ssp in self.proc_data_dict['sweep_points_2D_dict'][
                     qb_name].items():
                 if self.sp is not None:
-                    yunit = self.sp[1][pn][1]
+                    yunit = self.sp.get_sweep_params_property(
+                        'unit', dimension=2, param_names=pn)
                 self.plot_dicts[f'{plot_dict_name}_{pn}'] = {
                     'plotfn': self.plot_colorxy,
                     'fig_id': fig_name + '_' + pn,

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -3215,7 +3215,6 @@ class FluxAmplitudeSweepAnalysis(MultiQubit_TimeDomain_Analysis):
             for qb in self.qb_names}
         nr_sp2d = {qb: len(pdd['sweep_points_2D_dict'][qb][self.raw_data_dict['sweep_parameter_names'][1]])\
             for qb in self.qb_names}
-        print()
         nr_cp = self.num_cal_points
 
         # make matrix out of vector

--- a/pycqed/measurement/sweep_points.py
+++ b/pycqed/measurement/sweep_points.py
@@ -73,6 +73,94 @@ class SweepPoints(list):
     def add_sweep_dimension(self):
         self.append(dict())
 
+    def get_sweep_dimension(self, dimension='all'):
+        """
+        Returns the sweep dict of the sweep dimension specified by dimension.
+        :param dimension: int > 0 specifying a sweep dimension or
+            the string 'all'
+        :return: self if dimension == 'all', else self[dimension-1]
+        """
+        if dimension == 'all':
+            return self
+        else:
+            assert dimension > 0, 'Dimension must be > 0.'
+            if len(self) < dimension:
+                raise ValueError(f'Dimension {dimension} not found.')
+            return self[dimension-1]
+
+    def get_sweep_params_description(self, param_names, dimension='all'):
+        """
+        Get the sweep tuples for the sweep parameters param_names if they are
+        found in the sweep dimension dict specified by dimension.
+        :param param_names: string or list of strings corresponding to keys in
+            the dictionaries in self
+        :param dimension: see docstring for get_sweep_dimension
+        :return:
+            If the param_names are found in self or self[dimension]:
+            if param_names is string: string with the sweep tuples of each
+                param_names in the sweep dimension dict specified by dimension.
+            if param_names is list: list with the property of each
+                param_names in the sweep dimension dict specified by dimension.
+            if param_names is None: string corresponding to the
+                first sweep parameter in the sweep dimension dict
+            If none of param_names are found, raises KeyError.
+        """
+        sweep_points_dim = self.get_sweep_dimension(dimension)
+        is_list = True
+        if not isinstance(param_names, list):
+            param_names = [param_names]
+            is_list = False
+        sweep_param_values = []
+        if isinstance(sweep_points_dim, list):
+            for sweep_dim_dict in sweep_points_dim:
+                for pn in param_names:
+                    if pn in sweep_dim_dict:
+                        sweep_param_values += [sweep_dim_dict[pn]]
+        else:  # it is a dict
+            for pn in param_names:
+                if pn in sweep_points_dim:
+                    sweep_param_values += [sweep_points_dim[pn]]
+
+        if len(sweep_param_values) == 0:
+            s = "sweep points" if dimension == "all" else f'sweep dimension ' \
+                                                          f'{dimension}'
+            raise KeyError(f'{param_names} not found in {s}.')
+
+        if is_list:
+            return sweep_param_values
+        else:
+            return sweep_param_values[0]
+
+    def get_sweep_params_property(self, property, dimension, param_names=None):
+        """
+        Get a property of the sweep parameters param_names in self.
+        :param property: str with the name of a sweep param property. Can be
+            "values", "unit", "label."
+        :param dimension: int > 0 specifying a sweep dimension
+        :param param_names: None, or string or list of strings corresponding to
+            keys in the sweep dimension specified by dimension
+        :return:
+            if param_names is string: string with the property of each
+                param_names in the sweep dimension dict specified by dimension.
+            if param_names is list: list with the property of each
+                param_names in the sweep dimension dict specified by dimension.
+            if param_names is None: string corresponding to the
+                first sweep parameter in the sweep dimension dict
+        """
+        assert isinstance(dimension, int), 'Dimension must be an integer > 0.'
+        properties_dict = {'values': 0, 'unit': 1, 'label': 2}
+        if param_names is None:
+            return next(iter(self.get_sweep_dimension(
+                dimension).values()))[properties_dict[property]]
+        else:
+            if isinstance(param_names, list):
+                return [pnd[properties_dict[property]] for pnd in
+                        self.get_sweep_params_description(param_names,
+                                                          dimension)]
+            else:
+                return self.get_sweep_params_description(
+                    param_names, dimension)[properties_dict[property]]
+
     def get_meas_obj_sweep_points_map(self, measured_objects):
         """
         Assumes the order of params in each sweep dimension corresponds to
@@ -92,5 +180,4 @@ class SweepPoints(list):
             sweep_points_map[key] = [list(d)[i] for d in self]
 
         return sweep_points_map
-
 

--- a/pycqed/measurement/sweep_points.py
+++ b/pycqed/measurement/sweep_points.py
@@ -43,12 +43,24 @@ class SweepPoints(list):
         sp.add_sweep_parameter(f'amps_{qb}', np.linspace(0, 1, 20),
         'V', 'Pulse amplitude, $A$')
     """
-    def __init__(self, param_name=None, values=None, unit='', label=None):
+    def __init__(self, param_name=None, values=None, unit='', label=None,
+                 from_dict_list=None):
         super().__init__()
         if param_name is not None and values is not None:
             if label is None:
                 label = param_name
             self.append({param_name: (values, unit, label)})
+        elif from_dict_list is not None:
+            for d in from_dict_list:
+                if len(d) == 0 or isinstance(list(d.values())[0], tuple):
+                    # assume that dicts have the same format as this class
+                    self.append(d)
+                else:
+                    # import from a list of sweep dicts in the old format
+                    self.append({k: (v['values'],
+                                     v.get('unit',''),
+                                     v.get('label', k))
+                                 for k, v in d.items()})
 
     def add_sweep_parameter(self, param_name, values, unit='', label=None):
         if label is None:


### PR DESCRIPTION
Changes proposed in this pull request:
- Upgrades BaseDataAnalysis.add_measured_data to handle the case of hybrid measurements:
   conceptually a 2D measurement that was compressed along the 1st sweep dimension and
   the measurement was run in 1D mode.
- Fixes label and unit extraction in MultiQubit_TimeDomain_Analysis plotting function to
   work with SweepPoints.

This feature will be used automatically when the SweepPoints object for the measurement has 2 dimensions, but there is only one column of sweep points in the HDF5 file.

Analysis should be run with the flag TwoD == True (pass in options_dict).

!!! This feature only works if the SweepPoints are passed.

@antsr FYI
