### PR TITLE
Add proper renaming of segment

### DIFF
--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -1149,6 +1149,28 @@ class Segment:
         output += f'\n% {num_single_qb} single-qubit gates, {num_two_qb} two-qubit gates, {num_virtual} virtual gates'
         return output
 
+    def rename(self, new_name):
+        """
+        Renames a segment with the given new name. Hunts down element names in
+        unresolved pulses that might have made use of the old segment_name and renames
+        them too.
+        Args:
+            new_name:
+
+        Returns:
+
+        """
+        old_name = self.name
+
+        # rename element names in unresolved pulses making use of the old name
+        for p in self.unresolved_pulses:
+            if hasattr(p.pulse_obj, "element_name") \
+                and old_name in p.pulse_obj.element_name:
+                p.pulse_obj.element_name = p.pulse_obj.element_name.replace(old_name,
+                                                                            new_name)
+        # rename segment name
+        self.name = new_name
+
     def __deepcopy__(self, memo):
         cls = self.__class__
         new_seg = cls.__new__(cls)

--- a/pycqed/measurement/waveform_control/sequence.py
+++ b/pycqed/measurement/waveform_control/sequence.py
@@ -223,8 +223,9 @@ class Sequence:
                     except NameError:  # in case segment name exists, create new name
                         seg_occurences[-1][seg_name] += 1
                         new_name =seg_name + \
-                                   f"_copy_from_merge_{seg_occurences[-1][seg_name] - 1}"
-                        segment.name = new_name
+                                  f"_copy_from_merge_" \
+                                  f"{seg_occurences[-1][seg_name] - 1}"
+                        segment.rename(new_name)
                         merged_seqs[-1].add(segment)
 
                 segment_counter += seq.n_segments()


### PR DESCRIPTION
Renaming a segment after pulses have been added to it is not trivial because the name of the segment is used in some element names whenever the pulses are added.
This pull request introduces Segment.rename(new_name) that takes care of also renaming element_names. Using this feature in sequence.merge() allows for proper merge of repeat_patterns.
Inviting @stephlazar  to review


