### PR TITLE
do not crash in compare_instrument_settings_timestamp if a parameter cannot be treated by eval

### DIFF
--- a/pycqed/analysis/analysis_toolbox.py
+++ b/pycqed/analysis/analysis_toolbox.py
@@ -389,10 +389,15 @@ def compare_instrument_settings_timestamp(timestamp_a, timestamp_b):
                                             eval(ins_b.attrs[par_key]))
                     pass
                 except:
-                    print('    "%s" has a different value '
-                          ' "%s" for %s, "%s" for %s' % (
-                              par_key, eval(ins_a.attrs[par_key]), timestamp_a,
-                              eval(ins_b.attrs[par_key]), timestamp_b))
+                    try:
+                        print('    "%s" has a different value '
+                              ' "%s" for %s, "%s" for %s' % (
+                                  par_key, eval(ins_a.attrs[par_key]), timestamp_a,
+                                  eval(ins_b.attrs[par_key]), timestamp_b))
+                    except:
+                        # This happens if ins_a.attrs[par_key] or
+                        # ins_b.attrs[par_key] cannot be treated by eval.
+                        print('    Could not compare "%s".' % par_key)
                     diffs_found = True
 
             if not diffs_found:

--- a/pycqed/analysis/analysis_toolbox.py
+++ b/pycqed/analysis/analysis_toolbox.py
@@ -387,17 +387,16 @@ def compare_instrument_settings_timestamp(timestamp_a, timestamp_b):
                 try:
                     np.testing.assert_equal(eval(ins_a.attrs[par_key]),
                                             eval(ins_b.attrs[par_key]))
-                    pass
-                except:
-                    try:
-                        print('    "%s" has a different value '
-                              ' "%s" for %s, "%s" for %s' % (
-                                  par_key, eval(ins_a.attrs[par_key]), timestamp_a,
-                                  eval(ins_b.attrs[par_key]), timestamp_b))
-                    except:
-                        # This happens if ins_a.attrs[par_key] or
-                        # ins_b.attrs[par_key] cannot be treated by eval.
-                        print('    Could not compare "%s".' % par_key)
+                except AssertionError:
+                    print('    "%s" has a different value '
+                          ' "%s" for %s, "%s" for %s' % (
+                              par_key, eval(ins_a.attrs[par_key]), timestamp_a,
+                              eval(ins_b.attrs[par_key]), timestamp_b))
+                    diffs_found = True
+                except Exception:
+                    # This happens if ins_a.attrs[par_key] or
+                    # ins_b.attrs[par_key] cannot be treated by eval.
+                    print('    Could not compare "%s".' % par_key)
                     diffs_found = True
 
             if not diffs_found:


### PR DESCRIPTION
See title. This crash would happen for the new device object, whose qubits parameter becomes "[<QuDev_transmon: qb1>, <QuDev_transmon: qb2>, .... etc.]" when stored in the snapshot.

But independently of this particular case, error handling never hurts ;-).

The change was tested successfully on data from S17.
