### PR TITLE
bugfix measure_dynamic_phases: save correct preparation_params to metadata

### DIFF
--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -2778,7 +2778,7 @@ def measure_dynamic_phases(dev, qbc, qbt, cz_pulse_name, hard_sweep_params=None,
 
             if exp_metadata is None:
                 exp_metadata = {}
-            exp_metadata.update({'preparation_params': prep_params,
+            exp_metadata.update({'preparation_params': current_prep_params,
                                  'cal_points': repr(cp),
                                  'rotate': False if classified else
                                     len(cp.states) != 0,


### PR DESCRIPTION
See the title. The correct version is to store the current_prep_params that are passed to dynamic_phase_seq() a few lines above.

FYI @nathlacroix 