### PR TITLE
Allow FPS to use pulses from op_dict of device class

### DIFF
--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -3362,10 +3362,13 @@ class QuDev_transmon(Qubit):
             cp = None
         if prep_params is None:
             prep_params = self.preparation_params()
+
+        op_dict = kw.pop('operation_dict', self.get_operation_dict())
+
         seq, sweep_points, sweep_points_2D = \
             fsqs.fluxpulse_scope_sequence(
                 delays=delays, freqs=freqs, qb_name=self.name,
-                operation_dict=self.get_operation_dict(),
+                operation_dict=op_dict,
                 cz_pulse_name=cz_pulse_name, cal_points=cp,
                 prep_params=prep_params, upload=False, **kw)
         MC.set_sweep_function(awg_swf.SegmentHardSweep(


### PR DESCRIPTION
Allow flux pulse scope to accept operations_dict. This way the user can provide the operations dict of the device class. Together with providing the cz_pulse_name it is possible to use FPS to study the flux pulses of the device class.