### PR TITLE
Enh/parallel analysis

### DIFF
--- a/pycqed/analysis/analysis_toolbox.py
+++ b/pycqed/analysis/analysis_toolbox.py
@@ -16,7 +16,7 @@ from pycqed.utilities.get_default_datadir import get_default_datadir
 from scipy.interpolate import griddata
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from scipy.optimize import Bounds, LinearConstraint, minimize
-from .tools.plotting import *
+from pycqed.analysis.tools.plotting import *
 from matplotlib import cm
 
 

--- a/pycqed/analysis_v2/analysis_daemon.py
+++ b/pycqed/analysis_v2/analysis_daemon.py
@@ -4,15 +4,16 @@ import time
 import traceback
 import logging
 import os
+import matplotlib.pyplot as plt
 log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
 from pycqed.analysis import analysis_toolbox as a_tools
-a_tools.datadir = 'Q:\\USERS\\nathan\\data\\xld'
 
 class AnalysisDaemon:
     def __init__(self, t_start=None, start=True):
         self.t_start = t_start
         self.last_ts = None
-        self.poll_interval = 5  # seconds
+        self.poll_interval = 10  # seconds
         self.errs = []
         self.job_errs = []
         if start:
@@ -45,14 +46,16 @@ class AnalysisDaemon:
                                                       n_matches=1000)
         except ValueError as e:
             return  # could not find any timestamps matching criteria
-        log.info(f"Searching in: {timestamps}")
+        log.info(f"Searching jobs in: {timestamps[0]} ... {timestamps[-1]}.")
         for folder, ts in zip(folders, timestamps):
             jobs_in_folder = []
             for file in os.listdir(folder):
                 if file.endswith(".job"):
                     jobs_in_folder.append(os.path.join(folder, file))
             if len(jobs_in_folder) > 0:
-                log.info(f"Found {len(jobs_in_folder)} jobs in {ts}")
+                log.info(f"Found {len(jobs_in_folder)} job(s) in {ts}")
+            else:
+                log.info(f"No job found.")
 
             for filename in jobs_in_folder:
                 if os.path.isfile(filename):
@@ -84,9 +87,21 @@ class AnalysisDaemon:
     def run_job(self, job, ts):
         try:
             exec(job)
+            plt.close('all')
         except Exception as e:
             log.error(f"Error in job: {job}:\n{e}")
             self.job_errs.append(traceback.format_exc())
 
 if __name__ == "__main__":
-    ad = AnalysisDaemon(t_start=None)
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-dir", help="Watch directory")
+    parser.add_argument("--t-start", help="Starting watch time formatted as a "
+                                          "timestamp YYYYmmdd_hhMMss or string"
+                                          " 'now' (default).")
+    args = parser.parse_args()
+    if args.data_dir is not None:
+        a_tools.datadir = args.data_dir
+    if args.t_start == "now":
+        args.t_start = None
+    ad = AnalysisDaemon(t_start=args.t_start)

--- a/pycqed/analysis_v2/analysis_daemon.py
+++ b/pycqed/analysis_v2/analysis_daemon.py
@@ -41,6 +41,8 @@ class AnalysisDaemon:
         self.poll_interval = 10  # seconds
         self.errs = []
         self.job_errs = []
+        if watchdir is not None:
+            a_tools.datadir = watchdir
         if start:
             self.start()
 

--- a/pycqed/analysis_v2/analysis_daemon.py
+++ b/pycqed/analysis_v2/analysis_daemon.py
@@ -100,7 +100,7 @@ class AnalysisDaemon:
 
                     job = self.read_job(filename)
                     errl = len(self.job_errs)
-                    self.run_job(job, ts)
+                    self.run_job(job)
                     if errl == len(self.errs):
                         os.rename(filename, filename + '.done')
                     else:
@@ -111,19 +111,20 @@ class AnalysisDaemon:
         if not found_jobs:
             log.info(f"No new job found.")
 
-    def read_job(self, filename):
+    @staticmethod
+    def read_job(filename):
         job_file = open(filename, 'r')
         job = "".join(job_file.readlines())
         job_file.close()
         return job
-
-    def write_to_job(self, filename, new_lines):
+    @staticmethod
+    def write_to_job(filename, new_lines):
         job_file = open(filename, 'r+')
         job_file.write("\n")
         job_file.write("".join(new_lines))
         job_file.close()
 
-    def run_job(self, job, ts):
+    def run_job(self, job):
         try:
             exec(job)
             plt.close('all')

--- a/pycqed/analysis_v2/analysis_daemon.py
+++ b/pycqed/analysis_v2/analysis_daemon.py
@@ -1,0 +1,92 @@
+
+
+import time
+import traceback
+import logging
+import os
+log = logging.getLogger(__name__)
+from pycqed.analysis import analysis_toolbox as a_tools
+a_tools.datadir = 'Q:\\USERS\\nathan\\data\\xld'
+
+class AnalysisDaemon:
+    def __init__(self, t_start=None, start=True):
+        self.t_start = t_start
+        self.last_ts = None
+        self.poll_interval = 5  # seconds
+        self.errs = []
+        self.job_errs = []
+        if start:
+            self.start()
+
+    def start(self):
+        self.last_ts = a_tools.latest_data(older_than=self.t_start,
+                                           return_path=False,
+                                           return_timestamp=True, n_matches=1)[0]
+        self.run()
+
+    def run(self):
+        try:
+            while (True):
+                self.check_job()
+                for i in range(self.poll_interval):
+                    time.sleep(1)
+        except KeyboardInterrupt as e:
+            pass
+        except Exception as e:
+            log.error(e)
+            self.errs.append(traceback.format_exc())
+            self.run()
+
+    def check_job(self):
+        try:
+            timestamps, folders = a_tools.latest_data(newer_than=self.last_ts,
+                                                      raise_exc=False,
+                                                      return_timestamp=True,
+                                                      n_matches=1000)
+        except ValueError as e:
+            return  # could not find any timestamps matching criteria
+        log.info(f"Searching in: {timestamps}")
+        for folder, ts in zip(folders, timestamps):
+            jobs_in_folder = []
+            for file in os.listdir(folder):
+                if file.endswith(".job"):
+                    jobs_in_folder.append(os.path.join(folder, file))
+            if len(jobs_in_folder) > 0:
+                log.info(f"Found {len(jobs_in_folder)} jobs in {ts}")
+
+            for filename in jobs_in_folder:
+                if os.path.isfile(filename):
+                    time.sleep(1)  # wait to make sure that the file is fully written
+
+                    job = self.read_job(filename)
+                    errl = len(self.job_errs)
+                    self.run_job(job, ts)
+                    if errl == len(self.errs):
+                        os.rename(filename, filename + '.done')
+                    else:
+                        os.rename(filename, filename + '.failed')
+                        new_errors = self.errs[errl:]
+                        self.write_to_job(filename + '.failed', new_errors)
+                    self.last_ts = ts
+
+    def read_job(self, filename):
+        job_file = open(filename, 'r')
+        job = "".join(job_file.readlines())
+        job_file.close()
+        return job
+
+    def write_to_job(self, filename, new_lines):
+        job_file = open(filename, 'r+')
+        job_file.write("\n")
+        job_file.write("".join(new_lines))
+        job_file.close()
+
+    def run_job(self, job, ts):
+        try:
+            exec(job)
+        except Exception as e:
+            log.error(f"Error in job: {job}:\n{e}")
+            self.job_errs.append(traceback.format_exc())
+
+if __name__ == "__main__":
+    ad = AnalysisDaemon(t_start=None)

--- a/pycqed/analysis_v2/analysis_daemon.py
+++ b/pycqed/analysis_v2/analysis_daemon.py
@@ -10,7 +10,32 @@ log.setLevel(logging.INFO)
 from pycqed.analysis import analysis_toolbox as a_tools
 
 class AnalysisDaemon:
-    def __init__(self, t_start=None, start=True):
+    """
+    AnalysisDaemon is a class that allow to process analysis in a
+    separate python kernel to allow measurements to run in parallel
+    to the analysis.
+    The Daemon can either be started:
+     - in a separate ipython notebook using: `AnalysisDaemon(start=True)`.
+       Note that the a_tools.datadir should be set before calling the daemon
+       or passed with the watchdir argument
+     - via the commandline by calling `analysis_daemon.py` with possible
+       additional arguments (see `analysis_daemon.py --help`)
+     - with the start_analysis_daemon.bat script located in pycqedscripts/scripts
+       (Windows only)
+
+    """
+
+    def __init__(self, t_start=None, start=True, watchdir=None):
+        """
+        Initialize AnalysisDaemon
+        Args:
+            t_start (str): timestamp from which to start observing the data
+                directory. If None, defaults to now.
+            start (bool): whether or not to start the daemon
+            watchdir (str): directory which the Daemon should look at.
+                Defaults to analusis_toolbox.datadir.
+
+        """
         self.t_start = t_start
         self.last_ts = None
         self.poll_interval = 10  # seconds
@@ -20,6 +45,11 @@ class AnalysisDaemon:
             self.start()
 
     def start(self):
+        """
+        Starts the AnalysisDaemon
+        Returns:
+
+        """
         self.last_ts = a_tools.latest_data(older_than=self.t_start,
                                            return_path=False,
                                            return_timestamp=True, n_matches=1)[0]
@@ -39,6 +69,11 @@ class AnalysisDaemon:
             self.run()
 
     def check_job(self):
+        """
+        Checks whether new jobs have been found and processes them
+        Returns:
+
+        """
         try:
             timestamps, folders = a_tools.latest_data(newer_than=self.last_ts,
                                                       raise_exc=False,

--- a/pycqed/analysis_v2/analysis_daemon.py
+++ b/pycqed/analysis_v2/analysis_daemon.py
@@ -47,6 +47,7 @@ class AnalysisDaemon:
         except ValueError as e:
             return  # could not find any timestamps matching criteria
         log.info(f"Searching jobs in: {timestamps[0]} ... {timestamps[-1]}.")
+        found_jobs = False
         for folder, ts in zip(folders, timestamps):
             jobs_in_folder = []
             for file in os.listdir(folder):
@@ -54,8 +55,7 @@ class AnalysisDaemon:
                     jobs_in_folder.append(os.path.join(folder, file))
             if len(jobs_in_folder) > 0:
                 log.info(f"Found {len(jobs_in_folder)} job(s) in {ts}")
-            else:
-                log.info(f"No job found.")
+                found_jobs = True
 
             for filename in jobs_in_folder:
                 if os.path.isfile(filename):
@@ -71,6 +71,8 @@ class AnalysisDaemon:
                         new_errors = self.errs[errl:]
                         self.write_to_job(filename + '.failed', new_errors)
                     self.last_ts = ts
+        if not found_jobs:
+            log.info(f"No new job found.")
 
     def read_job(self, filename):
         job_file = open(filename, 'r')

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -183,11 +183,6 @@ class BaseDataAnalysis(object):
         self.options_dict['close_figs'] = self.options_dict.get(
             'close_figs', close_figs)
 
-        if not hasattr(self, "job"):
-            self.create_job(t_start=t_start, t_stop=t_stop,
-                 label=label, data_file_path=data_file_path,
-                 close_figs=close_figs, options_dict=options_dict,
-                 extract_only=extract_only, do_fitting=do_fitting)
 
         ####################################################
         # These options relate to what analysis to perform #
@@ -248,9 +243,9 @@ class BaseDataAnalysis(object):
 
         # if timestamp wasn't specified, specify it for the job
         if not "t_start" in kwargs or kwargs["t_start"] is None:
-            kwargs["t_start"] = self.timestamps[0]
+                kwargs["t_start"] = self.timestamps[0]
         if (not "t_stop" in kwargs or kwargs["t_stop"] is None) and \
-            len(self.timestamps) > 1:
+                len(self.timestamps) > 1:
             kwargs['t_stop'] = self.timestamps[-1]
         kwargs_list = [f'{k}={v if not isinstance(v, str) else repr(v)}'
                           for k, v in kwargs.items()]
@@ -737,7 +732,7 @@ class BaseDataAnalysis(object):
                         d = self._convert_dict_rec(copy.deepcopy(fit_res))
                         write_dict_to_hdf5(d, entry_point=fr_group)
                 except Exception as e:
-                    data_file.clsoe()
+                    data_file.close()
                     raise e
 
     def save_processed_data(self, key=None, overwrite=True):

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -243,7 +243,7 @@ class BaseDataAnalysis(object):
 
         # if timestamp wasn't specified, specify it for the job
         if not "t_start" in kwargs or kwargs["t_start"] is None:
-                kwargs["t_start"] = self.timestamps[0]
+            kwargs["t_start"] = self.timestamps[0]
         if (not "t_stop" in kwargs or kwargs["t_stop"] is None) and \
                 len(self.timestamps) > 1:
             kwargs['t_stop'] = self.timestamps[-1]

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -182,6 +182,13 @@ class BaseDataAnalysis(object):
             'save_figs', True)
         self.options_dict['close_figs'] = self.options_dict.get(
             'close_figs', close_figs)
+
+        if not hasattr(self, "job"):
+            self.create_job(t_start=t_start, t_stop=t_stop,
+                 label=label, data_file_path=data_file_path,
+                 close_figs=close_figs, options_dict=options_dict,
+                 extract_only=extract_only, do_fitting=do_fitting)
+
         ####################################################
         # These options relate to what analysis to perform #
         ####################################################
@@ -207,13 +214,72 @@ class BaseDataAnalysis(object):
             self.save_fit_results()
             self.analyze_fit_results()  # analyzing the results of the fits
 
-        self.prepare_plots()  # specify default plots
-        if not self.extract_only:
-            self.plot(key_list='auto')  # make the plots
+        delegate_plotting = self.check_plotting_delegation()
+        if not delegate_plotting:
+            self.prepare_plots()  # specify default plots
+            if not self.extract_only:
+                self.plot(key_list='auto')  # make the plots
 
-        if self.options_dict.get('save_figs', False):
-            self.save_figures(close_figs=self.options_dict.get(
-                'close_figs', False))
+            if self.options_dict.get('save_figs', False):
+                self.save_figures(close_figs=self.options_dict.get(
+                    'close_figs', False))
+
+    def create_job(self, *args, **kwargs):
+        """
+        Create a job string representation of the analysis to be processed
+        by an AnalysisDaemon.
+        Args:
+            *args: all arguments passed to the analysis init
+            **kwargs: all keyword arguments passed to the analysis init
+
+        Returns:
+
+        """
+        sep = ', ' if len(args) > 0 else ""
+        class_name = self.__class__.__name__
+
+        # prevent the job from calling itself in a loop
+        options_dict = copy.deepcopy(kwargs.get('options_dict', {}))
+        options_dict.pop('delegate_plotting', None)
+        kwargs['options_dict'] = options_dict
+
+        # prepare import
+        import_lines = f"from {self.__module__} import {class_name}\n"
+
+        # if timestamp wasn't specified, specify it for the job
+        if not "t_start" in kwargs or kwargs["t_start"] is None:
+            kwargs["t_start"] = self.timestamps[0]
+        if (not "t_stop" in kwargs or kwargs["t_stop"] is None) and \
+            len(self.timestamps) > 1:
+            kwargs['t_stop'] = self.timestamps[-1]
+        kwargs_list = [f'{k}={v if not isinstance(v, str) else repr(v)}'
+                          for k, v in kwargs.items()]
+
+        job_lines = f"{class_name}({', '.join(args)}{sep}{', '.join(kwargs_list)})"
+        self.job = f"{import_lines}{job_lines}"
+
+    def check_plotting_delegation(self):
+        """
+        Check whether the plotting and saving of figures should be delegated to an
+        analysis Daemon.
+        Returns:
+
+        """
+        if self.get_param_value("delegate_plotting", False):
+            if len(self.timestamps) == 1:
+                f = self.raw_data_dict['folder']
+            else:
+                f = self.raw_data_dict[0]['folder']
+            self.write_job(f, self.job)
+            return True
+        return False
+
+    @staticmethod
+    def write_job(folder, job, job_name="analysis.job"):
+        filepath = os.path.join(folder, job_name)
+
+        with open(filepath, "w") as f:
+            f.write(job)
 
     @staticmethod
     def get_hdf_datafile_param_value(group, param_name):

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5685,7 +5685,7 @@ class MultiQutrit_Timetrace_Analysis(ba.BaseDataAnalysis):
             self.numeric_params = list(self.params_dict)
 
         self.qb_names = qb_names
-        super().__init__( **kwargs)
+        super().__init__(auto=False, **kwargs)
 
         if auto:
             self.run_analysis()
@@ -5893,6 +5893,9 @@ class MultiQutrit_Singleshot_Readout_Analysis(MultiQubit_TimeDomain_Analysis):
         self.DEFAULT_CLASSIF = "gmm"
         self.classif_method = self.options_dict.get("classif_method",
                                                     self.DEFAULT_CLASSIF)
+
+        self.create_job(options_dict=options_dict, auto=auto, **kw)
+
         if auto:
             self.run_analysis()
 

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5691,10 +5691,7 @@ class MultiQutrit_Timetrace_Analysis(ba.BaseDataAnalysis):
             self.numeric_params = list(self.params_dict)
 
         self.qb_names = qb_names
-        super().__init__(auto=False, **kwargs)
-
-        if auto:
-            self.run_analysis()
+        super().__init__(auto=auto, **kwargs)
 
     def extract_data(self):
         super().extract_data()

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -211,6 +211,12 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
         if self.numeric_params is None:
             self.numeric_params = []
 
+        if not hasattr(self, "job"):
+            self.create_job(qb_names=qb_names, t_start=t_start, t_stop=t_stop,
+                            label=label, data_file_path=data_file_path,
+                            do_fitting=do_fitting, options_dict=options_dict,
+                            extract_only=extract_only, params_dict=params_dict,
+                            numeric_params=numeric_params, **kwargs)
         if auto:
             self.run_analysis()
 


### PR DESCRIPTION
Introduces an AnalysisDaemon to produce plots for analysis without interrupting measurements. Thanks to @chellings for the draft implementation. The following steps are required to run the daemon for basic calibration measurements:
1. create an analysis daemon, either by instanciating a class `AnalysisDaemon()` in a separate jupyter notebook (with the pycqed environment, and the correct datadirectory set in `a_tools`) or through commandline, again with appropritate pycqed environment started. e.g. `python analysis_daemon.py --data-dir D:\pydata` . A starting timestamp for the watching of the datafolder can be optionally specified witht the flag `--t-start`. Otherwise, the daemon will start watching any folder created after it the daemon was started. In `pycqedscripts/scripts`, there is a script called `start_analysis_daemon.bat` that starts the daemon with default settings for XLD/BF1. 
2. Pass the flag `delegate_plotting=True` through the options_dict to the analysis. This pull request adds the "delegate_plotting" flag to all basic calibration measurements functions in mqm, i.e. mutiqubit rabi, ramsey, qscale, t1, t2echo, ssro. 

Inviting @chellings to review. FYI @christiankraglundandersen @antsr @stephlazar 




