### PR TITLE
Devel/20 phase controlled nz

### DIFF
--- a/pycqed/measurement/pulse_sequences/fluxing_sequences.py
+++ b/pycqed/measurement/pulse_sequences/fluxing_sequences.py
@@ -344,13 +344,14 @@ def chevron_seqs(qbc_name, qbt_name, qbr_name, hard_sweep_dict, soft_sweep_dict,
         max_flux_length = max(hard_sweep_dict['pulse_length']['values'])
         ro_pulses[0]['ref_pulse'] = 'chevron_pi_qbc'
         ro_pulses[0]['pulse_delay'] = num_cz_gates * \
-            (max_flux_length + flux_pulse.get('buffer_length_start', 0) + \
-            flux_pulse.get('buffer_length_end', 0) + \
+            (max_flux_length + flux_pulse.get('buffer_length_start', 0) +
+            flux_pulse.get('buffer_length_end', 0) +
             # applies to FLIP gate only. An additional buffer, that can be used to make sure the FPs have rising edges
             # at different times.
-            nr_flux_buffer*flux_pulse.get('flux_buffer_length', 0) + \
-            nr_flux_buffer*flux_pulse.get('flux_buffer_length2', 0))
-
+            nr_flux_buffer*flux_pulse.get('flux_buffer_length', 0) +
+            nr_flux_buffer*flux_pulse.get('flux_buffer_length2', 0) +
+            # applies to transition-controlled gate only
+            nr_flux_buffer*flux_pulse.get('trans_length', 0))
     ssl = len(list(soft_sweep_dict.values())[0]['values'])
     sequences = []
     for i in range(ssl):
@@ -430,9 +431,10 @@ def fluxpulse_scope_sequence(
     ro_pulse['pulse_delay'] = ro_pulse_delay
     if ro_pulse_delay == 'auto':
         ro_pulse['ref_point'] = 'middle'
-        ro_pulse['pulse_delay'] = flux_pulse['pulse_length'] - np.min(delays) + \
-                                  flux_pulse.get('buffer_length_end', 0)
-
+        ro_pulse['pulse_delay'] = \
+            flux_pulse['pulse_length'] - np.min(delays) + \
+            flux_pulse.get('buffer_length_end', 0) + \
+            flux_pulse.get('trans_length', 0)
 
     pulses = [ge_pulse, flux_pulse, ro_pulse]
     swept_pulses = sweep_pulse_params(
@@ -500,7 +502,8 @@ def fluxpulse_amplitude_sequence(amplitudes,
 
 
     ro_pulse['pulse_delay'] = flux_pulse['pulse_length'] - delay + \
-                              flux_pulse.get('buffer_length_end', 0)
+                              flux_pulse.get('buffer_length_end', 0) + \
+                              flux_pulse.get('trans_length', 0)
 
     pulses = [ge_pulse, flux_pulse, ro_pulse]
     swept_pulses = sweep_pulse_params(pulses,
@@ -838,7 +841,8 @@ def cphase_seqs(qbc_name, qbt_name, hard_sweep_dict, soft_sweep_dict,
         # applies to FLIP gate only. An additional buffer, that can be used to make sure the FPs have rising edges at
         # different times.
         nr_flux_buffer*flux_pulse.get('flux_buffer_length', 0) +
-        nr_flux_buffer*flux_pulse.get('flux_buffer_length2', 0))
+        nr_flux_buffer*flux_pulse.get('flux_buffer_length2', 0) +
+        nr_flux_buffer*flux_pulse.get('trans_length', 0))
     # # ensure the delay is commensurate with 16/2.4e9
     # comm_const = (16/2.4e9)
     # if delay % comm_const > 1e-15:

--- a/pycqed/measurement/pulse_sequences/fluxing_sequences.py
+++ b/pycqed/measurement/pulse_sequences/fluxing_sequences.py
@@ -192,13 +192,11 @@ def dynamic_phase_seq(qb_names, hard_sweep_dict, operation_dict,
     pulse_list += [flux_pulse] + ge_half_end + ro_pulses
     hsl = len(list(hard_sweep_dict.values())[0]['values'])
 
-    if 'amplitude' in flux_pulse and 'amplitude2' not in flux_pulse:
-        params_to_set = ['amplitude']
-    elif 'dv_dphi' in flux_pulse:
-        params_to_set = ['dv_dphi']
-    elif 'amplitude' in flux_pulse and 'amplitude2' in flux_pulse:
-        params_to_set = ['amplitude', 'amplitude2']
-    else:
+    params_to_set = [param 
+        for param in ['amplitude', 'amplitude2', 'dv_dphi', 'trans_amplitude', 
+            'trans_amplitude2', 'amplitude_offset', 'amplitude_offset2'] 
+        if param in flux_pulse]
+    if len(params_to_set) == 0:
         raise ValueError('Unknown flux pulse amplitude control parameter. '
                          'Cannot do measurement without flux pulse.')
 
@@ -351,7 +349,7 @@ def chevron_seqs(qbc_name, qbt_name, qbr_name, hard_sweep_dict, soft_sweep_dict,
             nr_flux_buffer*flux_pulse.get('flux_buffer_length', 0) +
             nr_flux_buffer*flux_pulse.get('flux_buffer_length2', 0) +
             # applies to transition-controlled gate only
-            nr_flux_buffer*flux_pulse.get('trans_length', 0))
+            flux_pulse.get('trans_length', 0))
     ssl = len(list(soft_sweep_dict.values())[0]['values'])
     sequences = []
     for i in range(ssl):
@@ -842,7 +840,8 @@ def cphase_seqs(qbc_name, qbt_name, hard_sweep_dict, soft_sweep_dict,
         # different times.
         nr_flux_buffer*flux_pulse.get('flux_buffer_length', 0) +
         nr_flux_buffer*flux_pulse.get('flux_buffer_length2', 0) +
-        nr_flux_buffer*flux_pulse.get('trans_length', 0))
+        # applies to NZTC gate only
+        flux_pulse.get('trans_length', 0))
     # # ensure the delay is commensurate with 16/2.4e9
     # comm_const = (16/2.4e9)
     # if delay % comm_const > 1e-15:

--- a/pycqed/measurement/waveform_control/pulse.py
+++ b/pycqed/measurement/waveform_control/pulse.py
@@ -24,7 +24,7 @@ Each pulse library module should add itself to this set, e.g.
 """
 
 
-class Pulse:
+class Pulse(object):
     """
     The pulse base class.
 

--- a/pycqed/measurement/waveform_control/pulse.py
+++ b/pycqed/measurement/waveform_control/pulse.py
@@ -24,7 +24,7 @@ Each pulse library module should add itself to this set, e.g.
 """
 
 
-class Pulse(object):
+class Pulse:
     """
     The pulse base class.
 

--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -276,7 +276,7 @@ class NZTransitionControlledPulse(GaussianFilteredPiecewiseConstPulse):
                 self.lengths.append([bs + d, ml / 2, tl / 2,
                                      tl / 2, ml / 2, be - d])
             else:
-                if tl * ta < ml * ao:
+                if np.abs(tl * ta) < np.abs(ml * ao):
                     raise ValueError('NZTCPulse: Pick the pulse parameters '
                                      'such that "trans_len * trans_amplitude < '
                                      'pulse_length * amplitude_offset".')

--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -136,23 +136,20 @@ class GaussianFilteredPiecewiseConstPulse(pulse.Pulse):
         codeword (int or 'no_codeword'): The codeword that the pulse belongs in.
             Defaults to 'no_codeword'.
     """
-
-    def __init__(self, name, element_name, channels, lengths, amplitudes,
-                 gaussian_filter_sigma=0, codeword='no_codeword', **kw):
-        self.name = name
-        self.element_name = element_name
-        self.codeword = codeword
-        self.channels = channels
-        self._t0 = None
-
-        self.lengths = lengths
-        self.amplitudes = amplitudes
-        self.gaussian_filter_sigma = gaussian_filter_sigma
-
-        assert len(lengths) == len(channels)
-        assert len(amplitudes) == len(channels)
-        for l, a in zip(lengths, amplitudes):
-            assert len(l) == len(a)
+    @classmethod
+    def pulse_params(cls):
+        """
+        Returns a dictionary of pulse parameters and initial values. These
+        parameters are set upon calling the super().__init__ method.
+        """
+        params = {
+            'pulse_type': 'GaussianFilteredPiecewiseConstPulse',
+            'channels': None,
+            'lengths': None,
+            'amplitudes': 0,
+            'gaussian_filter_sigma': 0,
+        }
+        return params
 
     @property
     def length(self):
@@ -162,12 +159,18 @@ class GaussianFilteredPiecewiseConstPulse(pulse.Pulse):
         return max_len
 
     def _check_dimensions(self):
-        assert len(self.lengths) == len(self.channels)
-        assert len(self.amplitudes) == len(self.channels)
+        if len(self.lengths) != len(self.channels):
+            raise ValueError("Lengths list doesn't match channels list")
+        if len(self.amplitudes) != len(self.channels):
+            raise ValueError("Amplitudes list doesn't match channels list")
         for chan_lens, chan_amps in zip(self.lengths, self.amplitudes):
-            assert len(chan_lens) == len(chan_amps)
+            if len(chan_lens) != len(chan_amps):
+                raise ValueError("One of the amplitudes lists doesn't match "
+                                 "the corresponding lengths list")
 
     def chan_wf(self, channel, t):
+        self._check_dimensions()
+
         t0 = self.algorithm_time()
         idx = self.channels.index(channel)
         wave = np.zeros_like(t)
@@ -210,30 +213,12 @@ class NZTransitionControlledPulse(GaussianFilteredPiecewiseConstPulse):
     The zero area is achieved by adjusting the lengths for the intermediate
     pulses.
     """
-
     def __init__(self, name, element_name, **kw):
-        GaussianFilteredPiecewiseConstPulse.__init__(
-            self, name, element_name, [], [], [], **kw)
-        pulse.Pulse.__init__(self, name, element_name, **kw)
-
-        for par in ['amplitude', 'amplitude2', 'amplitude_offset',
-                    'amplitude_offset2', 'pulse_length', 'trans_amplitude',
-                    'trans_amplitude2', 'trans_length', 'buffer_length_start',
-                    'buffer_length_end', 'channel_relative_delay']:
-            self.add_value_change_callback(par, self._update_lengths_amps)
-        for par in ['channel', 'channel2']:
-            self.add_value_change_callback(par, self._update_channels)
-
-        self._update_lengths_amps()
-        self._update_channels()
+        super().__init__(name, element_name, **kw)
+        self._update_lengths_amps_channels()
 
     @classmethod
     def pulse_params(cls):
-        """
-        Returns a dictionary of pulse parameters and initial values.
-        These parameters are set upon calling the
-        super().__init__ method.
-        """
         params = {
             'pulse_type': 'NZTransitionControlledPulse',
             'channel': None,
@@ -253,10 +238,8 @@ class NZTransitionControlledPulse(GaussianFilteredPiecewiseConstPulse):
         }
         return params
 
-    def _update_channels(self):
+    def _update_lengths_amps_channels(self):
         self.channels = [self.channel, self.channel2]
-
-    def _update_lengths_amps(self):
         self.lengths = []
         self.amplitudes = []
 
@@ -283,16 +266,9 @@ class NZTransitionControlledPulse(GaussianFilteredPiecewiseConstPulse):
                 self.lengths.append([bs + d, ml / 2, (tl - ml * ao / ta) / 2,
                                      (tl + ml * ao / ta) / 2, ml / 2, be - d])
 
-    def add_value_change_callback(self, param, callback):
-        def getter(self):
-            return getattr(self, '_' + param)
-
-        def setter(self, value):
-            setattr(self, '_' + param, value)
-            callback()
-
-        setattr(self, '_' + param, getattr(self, param))
-        setattr(self.__class__, param, property(getter, setter))
+    def chan_wf(self, channel, t):
+        self._update_lengths_amps_channels()
+        return super().chan_wf(channel, t)
 
 
 class BufferedSquarePulse(pulse.Pulse):

--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -271,10 +271,15 @@ class NZTransitionControlledPulse(GaussianFilteredPiecewiseConstPulse):
             bs = self.buffer_length_start
             be = self.buffer_length_end
             self.amplitudes.append([0, ma + ao, ta, -ta, -ma + ao, 0])
+
             if ta == 0:
                 self.lengths.append([bs + d, ml / 2, tl / 2,
                                      tl / 2, ml / 2, be - d])
             else:
+                if tl * ta < ml * ao:
+                    raise ValueError('NZTCPulse: Pick the pulse parameters '
+                                     'such that "trans_len * trans_amplitude < '
+                                     'pulse_length * amplitude_offset".')
                 self.lengths.append([bs + d, ml / 2, (tl - ml * ao / ta) / 2,
                                      (tl + ml * ao / ta) / 2, ml / 2, be - d])
 

--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -260,9 +260,10 @@ class NZTransitionControlledPulse(GaussianFilteredPiecewiseConstPulse):
                                      tl / 2, ml / 2, be - d])
             else:
                 if np.abs(tl * ta) < np.abs(ml * ao):
-                    raise ValueError('NZTCPulse: Pick the pulse parameters '
-                                     'such that "trans_len * trans_amplitude < '
-                                     'pulse_length * amplitude_offset".')
+                    raise ValueError(
+                        'NZTCPulse: Pick the pulse parameters such that '
+                        '`abs(trans_len * trans_amplitude) >= abs(pulse_length'
+                        ' * amplitude_offset)`.')
                 self.lengths.append([bs + d, ml / 2, (tl - ml * ao / ta) / 2,
                                      (tl + ml * ao / ta) / 2, ml / 2, be - d])
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a net-zero pulse shape with additional tuning knobs to control the phase kick
value when transitioning from the first pulse half to the second pulse half

Tests done so far:
- [x] Program a Chevron measurement on a virtual setup
- [x] Try to tune up a gate with the new pulse shape

Plan is to merge only after testing on a real setup.

New pulse shape example with the following parameters
```
dev.get_pulse_par('CZ_nztransc', qb1, qb2, 'amplitude')(0.8)
dev.get_pulse_par('CZ_nztransc', qb1, qb2, 'amplitude2')(0.8)
dev.get_pulse_par('CZ_nztransc', qb1, qb2, 'pulse_length')(100e-9)
dev.get_pulse_par('CZ_nztransc', qb1, qb2, 'trans_length')(50e-9)
dev.get_pulse_par('CZ_nztransc', qb1, qb2, 'trans_amplitude')(0.4)
dev.get_pulse_par('CZ_nztransc', qb1, qb2, 'trans_amplitude2')(0.4)
dev.get_pulse_par('CZ_nztransc', qb1, qb2, 'gaussian_filter_sigma')(0.3e-9)
dev.get_pulse_par('CZ_nztransc', qb1, qb2, 'amplitude_offset')(0)
dev.get_pulse_par('CZ_nztransc', qb1, qb2, 'amplitude_offset2')(0.1)
```

![image](https://user-images.githubusercontent.com/1426628/85700917-23a0f480-b6dd-11ea-801e-ddbf3c0992a5.png)
