### PR TITLE
bugfix Device.measure_cphase: return results of mqm.measure_cphase

### DIFF
--- a/pycqed/instrument_drivers/meta_instrument/device.py
+++ b/pycqed/instrument_drivers/meta_instrument/device.py
@@ -463,7 +463,8 @@ class Device(Instrument):
         Wrapper function for the multi_qubit_module method measure_cphase.
         '''
 
-        mqm.measure_cphase(self, qbc, qbt, soft_sweep_params, cz_pulse_name, **kwargs)
+        return mqm.measure_cphase(self, qbc, qbt, soft_sweep_params,
+                                  cz_pulse_name, **kwargs)
 
     def measure_dynamic_phases(self, qbc, qbt, cz_pulse_name, **kwargs):
         """


### PR DESCRIPTION
Tiny bugfix from the XLD setup.