### PR TITLE
multi-qubit time-domain: use device object, more n_cal_points_per_state by default, and fixed docstrings

### DIFF
--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -3649,12 +3649,6 @@ def measure_n_qubit_rabi(dev, qubits, sweep_points=None, amps=None,
 
     MC = dev.instr_mc.get_instr()
 
-    # # check whether any qubits are connected
-    # for q1, q2 in list(itertools.combinations(qubits, 2)):
-    #     if [q1, q2] not in dev.connectivity_graph and \
-    #             [q2, q1] not in dev.connectivity_graph :
-    #         log.warning(f'{q1.name} and {q2.name} are connected.')
-
     if sweep_points is None:
         if amps is None:
             raise ValueError('Both "amps" and "sweep_points" cannot be None.')
@@ -3774,12 +3768,6 @@ def measure_n_qubit_ramsey(dev, qubits, sweep_points=None, delays=None,
         qubit_names = [qb.name for qb in qubits]
 
     MC = dev.instr_mc.get_instr()
-
-    # # check whether any qubits are connected
-    # for q1, q2 in list(itertools.combinations(qubits, 2)):
-    #     if [q1, q2] not in dev.connectivity_graph and \
-    #             [q2, q1] not in dev.connectivity_graph:
-    #         log.warning(f'{q1.name} and {q2.name} are connected.')
 
     if sweep_points is None:
         if delays is None:
@@ -3904,12 +3892,6 @@ def measure_n_qubit_qscale(dev, qubits, sweep_points=None, qscales=None,
 
     MC = dev.instr_mc.get_instr()
 
-    # # check whether any qubits are connected
-    # for q1, q2 in list(itertools.combinations(qubits, 2)):
-    #     if [q1, q2] not in dev.connectivity_graph and \
-    #             [q2, q1] not in dev.connectivity_graph:
-    #         log.warning(f'{q1.name} and {q2.name} are connected.')
-
     if sweep_points is None:
         if qscales is None:
             raise ValueError('Both "qscales" and "sweep_points" '
@@ -4022,12 +4004,6 @@ def measure_n_qubit_t1(dev, qubits, sweep_points=None, delays=None,
         qubit_names = [qb.name for qb in qubits]
 
     MC = dev.instr_mc.get_instr()
-
-    # # check whether any qubits are connected
-    # for q1, q2 in list(itertools.combinations(qubits, 2)):
-    #     if [q1, q2] not in dev.connectivity_graph and \
-    #             [q2, q1] not in dev.connectivity_graph:
-    #         log.warning(f'{q1.name} and {q2.name} are connected.')
 
     if sweep_points is None:
         if delays is None:
@@ -4142,12 +4118,6 @@ def measure_n_qubit_echo(dev, qubits, sweep_points=None, delays=None,
         qubit_names = [qb.name for qb in qubits]
 
     MC = dev.instr_mc.get_instr()
-
-    # # check whether any qubits are connected
-    # for q1, q2 in list(itertools.combinations(qubits, 2)):
-    #     if [q1, q2] not in dev.connectivity_graph and \
-    #             [q2, q1] not in dev.connectivity_graph:
-    #         log.warning(f'{q1.name} and {q2.name} are connected.')
 
     if sweep_points is None:
         if delays is None:

--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -3643,7 +3643,6 @@ def measure_n_qubit_rabi(dev, qubits, sweep_points=None, amps=None,
     """
     qubits = dev.get_qubits(qubits)
     qubit_names = [qb.name for qb in qubits]
-
     MC = dev.instr_mc.get_instr()
 
     if sweep_points is None:
@@ -3760,7 +3759,6 @@ def measure_n_qubit_ramsey(dev, qubits, sweep_points=None, delays=None,
     """
     qubits = dev.get_qubits(qubits)
     qubit_names = [qb.name for qb in qubits]
-
     MC = dev.instr_mc.get_instr()
 
     if sweep_points is None:
@@ -3785,7 +3783,6 @@ def measure_n_qubit_ramsey(dev, qubits, sweep_points=None, delays=None,
         label += get_multi_qubit_msmt_suffix(qubits)
 
     for qb in qubits:
-        MC = qb.instr_mc.get_instr()
         qb.prepare(drive='timedomain')
 
     cal_states = CalibrationPoints.guess_cal_states(cal_states,
@@ -3880,7 +3877,6 @@ def measure_n_qubit_qscale(dev, qubits, sweep_points=None, qscales=None,
     """
     qubits = dev.get_qubits(qubits)
     qubit_names = [qb.name for qb in qubits]
-
     MC = dev.instr_mc.get_instr()
 
     if sweep_points is None:
@@ -3906,7 +3902,6 @@ def measure_n_qubit_qscale(dev, qubits, sweep_points=None, qscales=None,
         label += get_multi_qubit_msmt_suffix(qubits)
 
     for qb in qubits:
-        MC = qb.instr_mc.get_instr()
         qb.prepare(drive='timedomain')
 
     cal_states = CalibrationPoints.guess_cal_states(cal_states,
@@ -3990,7 +3985,6 @@ def measure_n_qubit_t1(dev, qubits, sweep_points=None, delays=None,
     """
     qubits = dev.get_qubits(qubits)
     qubit_names = [qb.name for qb in qubits]
-
     MC = dev.instr_mc.get_instr()
 
     if sweep_points is None:
@@ -4015,7 +4009,6 @@ def measure_n_qubit_t1(dev, qubits, sweep_points=None, delays=None,
         label += get_multi_qubit_msmt_suffix(qubits)
 
     for qb in qubits:
-        MC = qb.instr_mc.get_instr()
         qb.prepare(drive='timedomain')
 
     cal_states = CalibrationPoints.guess_cal_states(cal_states,
@@ -4101,7 +4094,6 @@ def measure_n_qubit_echo(dev, qubits, sweep_points=None, delays=None,
     """
     qubits = dev.get_qubits(qubits)
     qubit_names = [qb.name for qb in qubits]
-
     MC = dev.instr_mc.get_instr()
 
     if sweep_points is None:
@@ -4126,7 +4118,6 @@ def measure_n_qubit_echo(dev, qubits, sweep_points=None, delays=None,
         label += get_multi_qubit_msmt_suffix(qubits)
 
     for qb in qubits:
-        MC = qb.instr_mc.get_instr()
         qb.prepare(drive='timedomain')
 
     cal_states = CalibrationPoints.guess_cal_states(cal_states,

--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -3641,11 +3641,8 @@ def measure_n_qubit_rabi(dev, qubits, sweep_points=None, amps=None,
     :param kw: keyword arguments. Are used in
         get_multiplexed_readout_detector_functions
     """
-    if all([isinstance(qb, str) for qb in qubits]):
-        qubit_names = qubits
-        qubits = [dev.get_qb(qb) for qb in qubits]
-    else:
-        qubit_names = [qb.name for qb in qubits]
+    qubits = dev.get_qubits(qubits)
+    qubit_names = [qb.name for qb in qubits]
 
     MC = dev.instr_mc.get_instr()
 
@@ -3761,11 +3758,8 @@ def measure_n_qubit_ramsey(dev, qubits, sweep_points=None, delays=None,
     :param kw: keyword arguments. Are used in
         get_multiplexed_readout_detector_functions
     """
-    if all([isinstance(qb, str) for qb in qubits]):
-        qubit_names = qubits
-        qubits = [dev.get_qb(qb) for qb in qubits]
-    else:
-        qubit_names = [qb.name for qb in qubits]
+    qubits = dev.get_qubits(qubits)
+    qubit_names = [qb.name for qb in qubits]
 
     MC = dev.instr_mc.get_instr()
 
@@ -3884,11 +3878,8 @@ def measure_n_qubit_qscale(dev, qubits, sweep_points=None, qscales=None,
     :param kw: keyword arguments. Are used in
         get_multiplexed_readout_detector_functions
     """
-    if all([isinstance(qb, str) for qb in qubits]):
-        qubit_names = qubits
-        qubits = [dev.get_qb(qb) for qb in qubits]
-    else:
-        qubit_names = [qb.name for qb in qubits]
+    qubits = dev.get_qubits(qubits)
+    qubit_names = [qb.name for qb in qubits]
 
     MC = dev.instr_mc.get_instr()
 
@@ -3997,11 +3988,8 @@ def measure_n_qubit_t1(dev, qubits, sweep_points=None, delays=None,
     :param kw: keyword arguments. Are used in
         get_multiplexed_readout_detector_functions
     """
-    if all([isinstance(qb, str) for qb in qubits]):
-        qubit_names = qubits
-        qubits = [dev.get_qb(qb) for qb in qubits]
-    else:
-        qubit_names = [qb.name for qb in qubits]
+    qubits = dev.get_qubits(qubits)
+    qubit_names = [qb.name for qb in qubits]
 
     MC = dev.instr_mc.get_instr()
 
@@ -4111,11 +4099,8 @@ def measure_n_qubit_echo(dev, qubits, sweep_points=None, delays=None,
     :param kw: keyword arguments. Are used in
         get_multiplexed_readout_detector_functions
     """
-    if all([isinstance(qb, str) for qb in qubits]):
-        qubit_names = qubits
-        qubits = [dev.get_qb(qb) for qb in qubits]
-    else:
-        qubit_names = [qb.name for qb in qubits]
+    qubits = dev.get_qubits(qubits)
+    qubit_names = [qb.name for qb in qubits]
 
     MC = dev.instr_mc.get_instr()
 

--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -3707,7 +3707,7 @@ def measure_n_qubit_rabi(dev, qubits, sweep_points=None, amps=None,
 
     if exp_metadata is None:
         exp_metadata = {}
-    exp_metadata.update({'qubit_names': qubit_names,
+    exp_metadata.update({'qb_names': qubit_names,
                          'preparation_params': prep_params,
                          'cal_points': repr(cp),
                          'sweep_points': sweep_points,
@@ -3824,7 +3824,8 @@ def measure_n_qubit_ramsey(dev, qubits, sweep_points=None, delays=None,
 
     if exp_metadata is None:
         exp_metadata = {}
-    exp_metadata.update({'preparation_params': prep_params,
+    exp_metadata.update({'qb_names': qubit_names,
+                         'preparation_params': prep_params,
                          'cal_points': repr(cp),
                          'sweep_points': sweep_points,
                          'artificial_detuning': artificial_detuning,
@@ -3944,7 +3945,8 @@ def measure_n_qubit_qscale(dev, qubits, sweep_points=None, qscales=None,
 
     if exp_metadata is None:
         exp_metadata = {}
-    exp_metadata.update({'preparation_params': prep_params,
+    exp_metadata.update({'qb_names': qubit_names,
+                         'preparation_params': prep_params,
                          'cal_points': repr(cp),
                          'sweep_points': sweep_points,
                          'meas_obj_sweep_points_map':
@@ -4055,7 +4057,8 @@ def measure_n_qubit_t1(dev, qubits, sweep_points=None, delays=None,
 
     if exp_metadata is None:
         exp_metadata = {}
-    exp_metadata.update({'preparation_params': prep_params,
+    exp_metadata.update({'qb_names': qubit_names,
+                         'preparation_params': prep_params,
                          'cal_points': repr(cp),
                          'sweep_points': sweep_points,
                          'meas_obj_sweep_points_map':
@@ -4169,7 +4172,8 @@ def measure_n_qubit_echo(dev, qubits, sweep_points=None, delays=None,
 
     if exp_metadata is None:
         exp_metadata = {}
-    exp_metadata.update({'preparation_params': prep_params,
+    exp_metadata.update({'qb_names': qubit_names,
+                         'preparation_params': prep_params,
                          'cal_points': repr(cp),
                          'sweep_points': sweep_points,
                          'meas_obj_sweep_points_map':


### PR DESCRIPTION
Changed and tested on the S17.