### PR TITLE
Enh/various analysis fixes and improvements

### DIFF
--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -770,8 +770,6 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
         return rotated_data_dict
 
     def get_xaxis_label_unit(self, qb_name):
-        # get xunit and label: temporarily with try catch for old
-        # sequences which do not have unit and label in meta data
         hard_sweep_params = self.get_param_value('hard_sweep_params')
         sweep_name = self.get_param_value('sweep_name')
         sweep_unit = self.get_param_value('sweep_unit')
@@ -788,6 +786,8 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
         else:
             xlabel = self.raw_data_dict['sweep_parameter_names']
             xunit = self.raw_data_dict['sweep_parameter_units']
+        if np.ndim(xlabel) > 0:
+            xlabel = xlabel[0]
         if np.ndim(xunit) > 0:
             xunit = xunit[0]
         return xlabel, xunit

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -4520,15 +4520,18 @@ class QScaleAnalysis(MultiQubit_TimeDomain_Analysis):
                 data = self.proc_data_dict['qscale_data'][qbn][
                     'data' + msmt_label]
 
+                # As a workaround for a weird bug letting crash the analysis
+                # every second time, we do not use lmfit.models.ConstantModel
+                # and lmfit.models.LinearModel, but create custom models.
                 if msmt_label == '_xx':
                     model = lmfit.Model(lambda x, c: c)
                     guess_pars = model.make_params(c=np.mean(data))
                 else:
                     model = lmfit.Model(lambda x, slope, intercept:
-                                        slope*x+intercept)
+                                        slope * x + intercept)
                     slope = (data[-1] - data[0]) / \
                             (sweep_points[-1] - sweep_points[0])
-                    intercept = data[-1] - slope*sweep_points[-1]
+                    intercept = data[-1] - slope * sweep_points[-1]
                     guess_pars = model.make_params(slope=slope,
                                                    intercept=intercept)
 

--- a/pycqed/analysis_v3/helper_functions.py
+++ b/pycqed/analysis_v3/helper_functions.py
@@ -68,20 +68,30 @@ def get_param_from_metadata_group(param_name, timestamp=None, data_file=None,
     return param_value
 
 
+def get_data_from_hdf_file(timestamp=None, data_file=None,
+                           close_file=True):
+    if data_file is None:
+        if timestamp is None:
+            raise ValueError('Please provide either timestamp or data_file.')
+        folder = a_tools.get_folder(timestamp)
+        h5filepath = a_tools.measurement_filename(folder)
+        data_file = h5py.File(h5filepath, 'r+')
+    group = data_file['Experimental Data']
+
+    if 'Data' in group:
+        dataset = np.array(group['Data'])
+    else:
+        raise KeyError(f'{Data} was not found in Experimental Data.')
+    if close_file:
+        data_file.close()
+    return dataset
+
+
 def get_data_file_from_timestamp(timestamp):
     folder = a_tools.get_folder(timestamp)
     h5filepath = a_tools.measurement_filename(folder)
     data_file = h5py.File(h5filepath, 'r+')
-    try:
-        group = data_file['Experimental Data'][
-            'Experimental Metadata']['sweep_points']
-        sweep_points = OrderedDict()
-        sweep_points = read_dict_from_hdf5(sweep_points, group)
-        data_file.close()
-        return sweep_points
-    except Exception as e:
-        data_file.close()
-        raise e
+    return data_file
 
 
 def get_params_from_hdf_file(data_dict, params_dict=None, numeric_params=None,

--- a/pycqed/analysis_v3/helper_functions.py
+++ b/pycqed/analysis_v3/helper_functions.py
@@ -70,21 +70,25 @@ def get_param_from_metadata_group(timestamp=None, param_name=None,
         h5filepath = a_tools.measurement_filename(folder)
         data_file = h5py.File(h5filepath, 'r+')
 
-    if param_name is None:
-        group = data_file['Experimental Data']
-        return read_dict_from_hdf5({}, group['Experimental Metadata'])
+    try:
+        if param_name is None:
+            group = data_file['Experimental Data']
+            return read_dict_from_hdf5({}, group['Experimental Metadata'])
 
-    group = data_file['Experimental Data']['Experimental Metadata']
-    if param_name in group:
-        group = group[param_name]
-        param_value = OrderedDict()
-        param_value = read_dict_from_hdf5(param_value, group)
-    elif param_name in group.attrs:
-        param_value = get_hdf_param_value(group, param_name)
-    else:
-        raise KeyError(f'{param_name} was not found in metadata.')
-    if close_file:
+        group = data_file['Experimental Data']['Experimental Metadata']
+        if param_name in group:
+            group = group[param_name]
+            param_value = OrderedDict()
+            param_value = read_dict_from_hdf5(param_value, group)
+        elif param_name in group.attrs:
+            param_value = get_hdf_param_value(group, param_name)
+        else:
+            raise KeyError(f'{param_name} was not found in metadata.')
+        if close_file:
+            data_file.close()
+    except Exception as e:
         data_file.close()
+        raise e
     return param_value
 
 
@@ -104,14 +108,17 @@ def get_data_from_hdf_file(timestamp=None, data_file=None,
         folder = a_tools.get_folder(timestamp)
         h5filepath = a_tools.measurement_filename(folder)
         data_file = h5py.File(h5filepath, 'r+')
-    group = data_file['Experimental Data']
-
-    if 'Data' in group:
-        dataset = np.array(group['Data'])
-    else:
-        raise KeyError(f'{Data} was not found in Experimental Data.')
-    if close_file:
+    try:
+        group = data_file['Experimental Data']
+        if 'Data' in group:
+            dataset = np.array(group['Data'])
+        else:
+            raise KeyError(f'{Data} was not found in Experimental Data.')
+        if close_file:
+            data_file.close()
+    except Exception as e:
         data_file.close()
+        raise e
     return dataset
 
 

--- a/pycqed/analysis_v3/helper_functions.py
+++ b/pycqed/analysis_v3/helper_functions.py
@@ -32,6 +32,11 @@ def get_hdf_param_value(group, param_name):
 
 
 def get_value_names_from_timestamp(timestamp):
+    """
+    Returns value_names from the HDF5 file specified by timestamp.
+    :param timestamp: (str) measurement timestamp of form YYYYMMDD_hhmmsss
+    :return: list of value_names
+    """
     folder = a_tools.get_folder(timestamp)
     h5filepath = a_tools.measurement_filename(folder)
     data_file = h5py.File(h5filepath, 'r+')
@@ -45,16 +50,31 @@ def get_value_names_from_timestamp(timestamp):
         raise e
 
 
-def get_param_from_metadata_group(param_name, timestamp=None, data_file=None,
-                                  close_file=True):
+def get_param_from_metadata_group(timestamp=None, param_name=None,
+                                  data_file=None, close_file=True):
+    """
+    Get a parameter with param_name from the Experimental Metadata group in
+    the HDF5 file specified by timestamp, or return the whole group if
+    param_name is None.
+    :param timestamp: (str) measurement timestamp of form YYYYMMDD_hhmmsss
+    :param param_name: (str) name of a key in Experimental Metadata group
+    :param data_file: (HDF file) opened HDF5 file
+    :param close_file: (bool) whether to close the HDF5 file
+    :return: the value of the param_name or the whole experimental metadata
+    dictionary
+    """
     if data_file is None:
         if timestamp is None:
             raise ValueError('Please provide either timestamp or data_file.')
         folder = a_tools.get_folder(timestamp)
         h5filepath = a_tools.measurement_filename(folder)
         data_file = h5py.File(h5filepath, 'r+')
-    group = data_file['Experimental Data']['Experimental Metadata']
 
+    if param_name is None:
+        group = data_file['Experimental Data']
+        return read_dict_from_hdf5({}, group['Experimental Metadata'])
+
+    group = data_file['Experimental Data']['Experimental Metadata']
     if param_name in group:
         group = group[param_name]
         param_value = OrderedDict()
@@ -70,6 +90,14 @@ def get_param_from_metadata_group(param_name, timestamp=None, data_file=None,
 
 def get_data_from_hdf_file(timestamp=None, data_file=None,
                            close_file=True):
+    """
+    Return the measurement data stored in Experimental Data group of the file
+    specified by timestamp.
+    :param timestamp: (str) measurement timestamp of form YYYYMMDD_hhmmsss
+    :param data_file: (HDF file) opened HDF5 file
+    :param close_file: (bool) whether to close the HDF5 file
+    :return: numpy array with measurement data
+    """
     if data_file is None:
         if timestamp is None:
             raise ValueError('Please provide either timestamp or data_file.')
@@ -87,10 +115,17 @@ def get_data_from_hdf_file(timestamp=None, data_file=None,
     return dataset
 
 
-def get_data_file_from_timestamp(timestamp):
+def open_data_file_from_timestamp(timestamp, mode='r+'):
+    """
+    Return the opened HDF5 file specified by timestamp.
+    ! File is not closed !
+    :param timestamp: (str) measurement timestamp of form YYYYMMDD_hhmmsss
+    :param mode: (str) in what mode to open the file
+    :return: open HDF5 file
+    """
     folder = a_tools.get_folder(timestamp)
     h5filepath = a_tools.measurement_filename(folder)
-    data_file = h5py.File(h5filepath, 'r+')
+    data_file = h5py.File(h5filepath, mode)
     return data_file
 
 


### PR DESCRIPTION
Various improvements and bug fixes to analysis_v2 and helper_functions.py.

Changes proposed in this pull request:
- Adds extraction of xlabel and xunit from SweepPoints in RamseyAnalysis and QScaleAnalysis.
- Improves MultiQubit_TimeDomain_Analysis.extract_data() to first check for meas_obj_value_names_map in
   the metadata for extracting channel_map.
- Fixes bug in MultiQubit_TimeDomain_Analysis.get_cal_data_points() and cal_states_analysis() that prevented
   using the analysis without calibration states (i.e. with PCA).
- Adds get_data_from_hdf_file to helper_functions.py.
- Fixes bug in get_data_file_from_timestamp that might have occurred in a merge.

@chellings maybe can review?

