### PR TITLE
CPhaseLeakageAnalysis: remove absolute value in population loss calculation

### DIFF
--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5236,7 +5236,7 @@ class CPhaseLeakageAnalysis(MultiQubit_TimeDomain_Analysis):
                                 for fr in fit_res_objs])
         amps_errs[amps_errs == None] = 0.0
 
-        population_loss = np.abs(amps[0::2] - amps[1::2])/amps[1::2]
+        population_loss = amps[0::2] - amps[1::2]/amps[1::2]
         x   = amps[0::2] - amps[1::2]
         x_err = np.array(amps_errs[0::2]**2 + amps_errs[1::2]**2,
                          dtype=np.float64)


### PR DESCRIPTION
After this change, a negative population loss would indicate that the e-state population with gate is higher than without.

From the XLD setup.
