### PR TITLE
ZI_HDAWG_core: raise errors detected during runtime

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG_core.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_HDAWG_core.py
@@ -293,8 +293,8 @@ class ZI_HDAWG_core(zibase.ZI_base_instrument):
                         'message': message
                     }
 
-        # if found_errors:
-        #     raise zibase.ziRuntimeError('Errors detected during run-time!')
+        if found_errors:
+            raise zibase.ziRuntimeError('Errors detected during run-time!')
 
     def clear_errors(self):
         self.seti('raw/error/clear', 1)


### PR DESCRIPTION
This was commented out earlier as a workaround, and it has now been tested successfully on XLD to have this check in the code again.