### PR TITLE
Hotfix: BaseAnalysis.create_job: do not crash if options_dict is None

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -237,6 +237,8 @@ class BaseDataAnalysis(object):
 
         # prevent the job from calling itself in a loop
         options_dict = copy.deepcopy(kwargs.get('options_dict', {}))
+        if options_dict is None:
+            options_dict = {}
         options_dict.pop('delegate_plotting', None)
         kwargs['options_dict'] = options_dict
 


### PR DESCRIPTION
This it to avoid the following error, where options_dict exists, but it None:
```
c:\software\python\pycqed_py3\pycqed\instrument_drivers\meta_instrument\qubit_objects\QuDev_transmon.py in find_amplitudes(self, rabi_amps, label, for_ef, n_cal_points_per_state, cal_states, upload, last_ge_pulse, classified_ro, prep_params, analyze, update, exp_metadata, **kw)
   2405         #get pi and pi/2 amplitudes from the analysis results
   2406         if analyze:
-> 2407             rabi_ana = tda.RabiAnalysis(qb_names=[self.name])
   2408             if update:
   2409                 amp180 = rabi_ana.proc_data_dict['analysis_params_dict'][

c:\software\python\pycqed_py3\pycqed\analysis_v2\timedomain_analysis.py in __init__(self, qb_names, *args, **kwargs)
   4125         kwargs['params_dict'] = params_dict
   4126         kwargs['numeric_params'] = list(params_dict)
-> 4127         super().__init__(qb_names, *args, **kwargs)
   4128 
   4129     def prepare_fitting(self):

c:\software\python\pycqed_py3\pycqed\analysis_v2\timedomain_analysis.py in __init__(self, qb_names, label, t_start, t_stop, data_file_path, options_dict, extract_only, do_fitting, auto, params_dict, numeric_params, **kwargs)
    218                             do_fitting=do_fitting, options_dict=options_dict,
    219                             extract_only=extract_only, params_dict=params_dict,
--> 220                             numeric_params=numeric_params, **kwargs)
    221         if auto:
    222             self.run_analysis()

c:\software\python\pycqed_py3\pycqed\analysis_v2\base_analysis.py in create_job(self, *args, **kwargs)
    238         # prevent the job from calling itself in a loop
    239         options_dict = copy.deepcopy(kwargs.get('options_dict', {}))
--> 240         options_dict.pop('delegate_plotting', None)
    241         kwargs['options_dict'] = options_dict
    242 

AttributeError: 'NoneType' object has no attribute 'pop'
```
