### PR TITLE
bugfix Segment.rename: search element names also in unresolved_pulses

### DIFF
--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -1178,8 +1178,9 @@ class Segment:
         """
         old_name = self.name
 
-        # rename element names in unresolved pulses making use of the old name
-        for p in self.resolved_pulses:
+        # rename element names in unresolved_pulses and resolved_pulses making
+        # use of the old name
+        for p in self.unresolved_pulses + self.resolved_pulses:
             if hasattr(p.pulse_obj, "element_name") \
                 and old_name in p.pulse_obj.element_name:
                 p.pulse_obj.element_name = p.pulse_obj.element_name.replace(old_name,

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -1182,9 +1182,10 @@ class Segment:
         # use of the old name
         for p in self.unresolved_pulses + self.resolved_pulses:
             if hasattr(p.pulse_obj, "element_name") \
-                and old_name in p.pulse_obj.element_name:
-                p.pulse_obj.element_name = p.pulse_obj.element_name.replace(old_name,
-                                                                            new_name)
+                    and p.pulse_obj.element_name.endswith(f"_{old_name}"):
+                p.pulse_obj.element_name = \
+                    p.pulse_obj.element_name[:-(len(old_name) + 1)] + '_' \
+                    + new_name
         # rename segment name
         self.name = new_name
 


### PR DESCRIPTION
The bug, which prevented 2D sweep compression from working properly, appeared as a consequence of introducing the distinction between unresolved_pulses and resolved_pulses. Since it cannot be foreseen at which stage someone will rename a segment, we need a generic solution and thus have to search for element names both resolved and unresolved pulses.