### PR TITLE
Feature/clean interrupt

### DIFF
--- a/pycqed/analysis/measurement_analysis.py
+++ b/pycqed/analysis/measurement_analysis.py
@@ -6625,7 +6625,8 @@ class FluxPulse_Scope_Analysis(MeasurementAnalysis):
         if len(self.exp_metadata) != 0:
             try:
                 self.delays = self.exp_metadata['sweep_points_dict'][self.qb_name]
-                self.freqs = self.exp_metadata['sweep_points_dict_2D'][self.qb_name]
+                self.freqs = self.exp_metadata['sweep_points_dict_2D'][
+                    self.qb_name][:len(self.sweep_points_2D)]
                 cp = self.exp_metadata.get('cal_points', None)
                 if cp is not None:
                     cp = CalibrationPoints.from_string(cp)

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -306,6 +306,13 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                 self.proc_data_dict['sweep_points_2D_dict'] = \
                     {qbn: {sspn[i]: self.raw_data_dict['soft_sweep_points'][i]
                            for i in range(len(sspn))} for qbn in self.qb_names}
+        percentage_done = self.get_param_value('percentage_done', 100)
+        if percentage_done < 100:
+            for sps in self.proc_data_dict['sweep_points_2D_dict'].values():
+                nr_sp2d = int(round(len(list(sps.values())[0]) *
+                                    percentage_done / 100))
+                for k, v in sps.items():
+                    sps[k] = v[:nr_sp2d]
 
     def create_meas_results_per_qb(self):
         measured_RO_channels = list(self.raw_data_dict['measured_data'])

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -306,13 +306,15 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                 self.proc_data_dict['sweep_points_2D_dict'] = \
                     {qbn: {sspn[i]: self.raw_data_dict['soft_sweep_points'][i]
                            for i in range(len(sspn))} for qbn in self.qb_names}
-        percentage_done = self.get_param_value('percentage_done', 100)
-        if percentage_done < 100:
-            for sps in self.proc_data_dict['sweep_points_2D_dict'].values():
-                nr_sp2d = int(round(len(list(sps.values())[0]) *
-                                    percentage_done / 100))
-                for k, v in sps.items():
-                    sps[k] = v[:nr_sp2d]
+        # remove non-measured sweep points in that case in case the
+        # measurement was cancelled
+        # raw_data_dict['soft_sweep_points'] is obtained in
+        # BaseDataAnalysis.add_measured_data(), and its length should
+        # always correspond to the actual number of measured soft sweep points.
+        ssl = len(self.raw_data_dict['soft_sweep_points'])
+        for sps in self.proc_data_dict['sweep_points_2D_dict'].values():
+            for k, v in sps.items():
+                sps[k] = v[:ssl]
 
     def create_meas_results_per_qb(self):
         measured_RO_channels = list(self.raw_data_dict['measured_data'])

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -306,15 +306,17 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                 self.proc_data_dict['sweep_points_2D_dict'] = \
                     {qbn: {sspn[i]: self.raw_data_dict['soft_sweep_points'][i]
                            for i in range(len(sspn))} for qbn in self.qb_names}
-        # remove non-measured sweep points in that case in case the
-        # measurement was cancelled
-        # raw_data_dict['soft_sweep_points'] is obtained in
-        # BaseDataAnalysis.add_measured_data(), and its length should
-        # always correspond to the actual number of measured soft sweep points.
-        ssl = len(self.raw_data_dict['soft_sweep_points'])
-        for sps in self.proc_data_dict['sweep_points_2D_dict'].values():
-            for k, v in sps.items():
-                sps[k] = v[:ssl]
+        if self.get_param_value('percentage_done', 100) < 100:
+            # This indicated an interrupted measurement.
+            # Remove non-measured sweep points in that case.
+            # raw_data_dict['soft_sweep_points'] is obtained in
+            # BaseDataAnalysis.add_measured_data(), and its length should
+            # always correspond to the actual number of measured soft sweep
+            # points.
+            ssl = len(self.raw_data_dict['soft_sweep_points'])
+            for sps in self.proc_data_dict['sweep_points_2D_dict'].values():
+                for k, v in sps.items():
+                    sps[k] = v[:ssl]
 
     def create_meas_results_per_qb(self):
         measured_RO_channels = list(self.raw_data_dict['measured_data'])

--- a/pycqed/measurement/measurement_control.py
+++ b/pycqed/measurement/measurement_control.py
@@ -86,6 +86,10 @@ class MeasurementControl(Instrument):
                            vals=vals.Bool(),
                            parameter_class=ManualParameter,
                            initial_value=False)
+        self.add_parameter('clean_interrupt',
+                           vals=vals.Bool(),
+                           parameter_class=ManualParameter,
+                           initial_value=False)
 
         self.add_parameter(
             'cfg_clipping_mode', vals=vals.Bool(),
@@ -211,6 +215,15 @@ class MeasurementControl(Instrument):
                                      .format(self.mode))
             except KeyboardFinish as e:
                 print(e)
+            except KeyboardInterrupt as e:
+                percentage_done = self.get_percdone()
+                if percentage_done == 0 or not self.clean_interrupt():
+                    raise e
+                self.save_exp_metadata({'percentage_done': percentage_done},
+                                       self.data_object)
+                logging.warning('Caught a KeyboardInterrupt and there is '
+                                'unsaved data. Trying clean exit to save '
+                                'data.')
             result = self.dset[()]
             self.get_measurement_endtime()
             self.save_MC_metadata(self.data_object)  # timing labels etc


### PR DESCRIPTION
Allow saving and analyzing partial data when interrupting a 2D sweep.
This feature can be enabled by setting the new parameter MC.clean_interrupt to True.

Then, when interrupting while recording a softsweep, MC will save the data, and if you call timedomain analysis, it can create raw and projected plots for the part measured before cancellation. Dedicated analysis functions might need to be adapted if it is intended that they can also deal with data from interrupted measurements. This pull request concerns such a modification for the FluxPulseScope analysis.

Tested on S17.

FYI @antsr 