### PR TITLE
SegmentHardSweep: do not issue warning when set_parameter is called

### DIFF
--- a/pycqed/measurement/awg_sweep_functions.py
+++ b/pycqed/measurement/awg_sweep_functions.py
@@ -160,6 +160,9 @@ class SegmentHardSweep(swf.Hard_Sweep):
                                                   awgs=awgs_to_upload)
             time.sleep(0.1)
 
+    def set_parameter(self, value):
+        pass
+
 
 class SegmentSoftSweep(swf.Soft_Sweep):
 


### PR DESCRIPTION
The change overloads the function in Hard_Sweep, which issues the warning.
MC systematically calls set_parameter, but in the framework of a segment sweep, performing no action is the correct behavior. So no warning is needed.

Tested on a virtual setup.

Inviting @antsr to review.
FYI @stephlazar