### PR TITLE
Bugfix: unique ylabels for projected plots in ana_v2

### DIFF
--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -833,7 +833,8 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                             plot_name_suffix = ''
                             plot_cal_points = (
                                 not self.options_dict.get('TwoD', False))
-                            data_axis_label = ''
+                            data_axis_label = '{} state population'.format(
+                                self.get_latex_prob_label(data_key))
                         self.prepare_projected_data_plot(
                             fig_name, data, qb_name=qb_name,
                             data_label=data_label,


### PR DESCRIPTION
Fixes bug in MultiQubit_TimeDomain_Analysis.prepare_projected_data_plot() where the plot for each probability had the same ylabel/zlabel.


