### PR TITLE
Bugfixes in mode matched weights measurement and analysis

### DIFF
--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5737,7 +5737,9 @@ class MultiQutrit_Timetrace_Analysis(ba.BaseDataAnalysis):
             self.numeric_params = list(self.params_dict)
 
         self.qb_names = qb_names
-        super().__init__(auto=auto, **kwargs)
+        super().__init__(**kwargs)
+        if auto:
+            self.run_analysis()
 
     def extract_data(self):
         super().extract_data()
@@ -5861,13 +5863,11 @@ class MultiQutrit_Timetrace_Analysis(ba.BaseDataAnalysis):
                         'ax_id': ax_id,
                         'plotfn': self.plot_line,
                         'xvals': tbase,
-                        'xunit': 's',
                         "marker": "",
                         'yvals': func(ttrace*modulation),
                         'ylabel': 'Voltage, $V$',
                         'yunit': 'V',
                         "sharex": True,
-                        "xrange": (0, self.get_param_value('tmax', 400e-9, 0)),
                         "setdesc": label + f"_{state}",
                         "setlabel": "",
                         "do_legend":True,
@@ -5892,7 +5892,7 @@ class MultiQutrit_Timetrace_Analysis(ba.BaseDataAnalysis):
                         'yvals': func(weights * modulation),
                         'ylabel': 'Voltage, $V$ (arb.u.)',
                         "sharex": True,
-                        "xrange": (0, self.get_param_value('tmax', 400e-9, 0)),
+                        "xrange": (0, self.get_param_value('tmax', 1200e-9, 0)),
                         "setdesc": label + f"_{i+1}",
                         "do_legend": True,
                         "legend_pos": "upper right",

--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -646,7 +646,7 @@ def find_optimal_weights(dev, qubits, states=('g', 'e'), upload=True,
 
         for state in states:
             # create sequence
-            name = 'timetrace_{}_{}'.format(state, qb_names)
+            name = f'timetrace_{state}{get_multi_qubit_msmt_suffix(qubits)}'
             if isinstance(state, str) and len(state) == 1:
                 # same state for all qubits, e.g. "e"
                 cp = CalibrationPoints.multi_qubit(qb_names, state,


### PR DESCRIPTION
Tested on S17

- mqm.find_optimal_weights: fixed the label 
- bugfixes MultiQutrit_Timetrace_Analysis:
 - fixed use of auto
 - define xrange and xunit only once for shared x-axis
 - longer default value for tmax

FYI @stephlazar 

