### PR TITLE
Bugfix channels_to_upload in measure_cphase

### DIFF
--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -2482,6 +2482,10 @@ def measure_cphase(dev, qbc, qbt, soft_sweep_params, cz_pulse_name,
 
     channels_to_upload = [operation_dict[cz_pulse_name +
                                          f' {qbc.name} {qbt.name}']['channel']]
+    if 'channel2' in operation_dict[cz_pulse_name + f' {qbc.name} {qbt.name}']:
+        channels_to_upload += [operation_dict[cz_pulse_name +
+                                         f' {qbc.name} {qbt.name}']['channel2']]
+
     MC.set_sweep_function_2D(awg_swf.SegmentSoftSweep(
         hard_sweep_func, sequences,
         list(soft_sweep_params)[0], list(soft_sweep_params.values())[0]['unit'],


### PR DESCRIPTION
measure_cphase: if channel2 exists in a flux pulse, add it to channels_to_upload

From the S17 branch

FYI @antsr 