### PR TITLE
hdf5_data: replaced a deprecated call with the up-to-date version in h5py 2.1

### DIFF
--- a/pycqed/measurement/hdf5_data.py
+++ b/pycqed/measurement/hdf5_data.py
@@ -282,15 +282,15 @@ def read_dict_from_hdf5(data_dict: dict, h5_group):
                                                  item)
         else:  # item either a group or a dataset
             if 'list_type' not in item.attrs:
-                data_dict[key] = item.value
+                data_dict[key] = item[()]
             elif item.attrs['list_type'] == 'str':
                 # lists of strings needs some special care, see also
                 # the writing part in the writing function above.
-                list_of_str = [x[0] for x in item.value]
+                list_of_str = [x[0] for x in item[()]]
                 data_dict[key] = list_of_str
 
             else:
-                data_dict[key] = list(item.value)
+                data_dict[key] = list(item[()])
     for key, item in h5_group.attrs.items():
         if isinstance(item, str):
             # Extracts "None" as an exception as h5py does not support


### PR DESCRIPTION
The change follows the instructions on http://docs.h5py.org/en/stable/whatsnew/2.1.html

Tested on S17

FYI @antsr 