### PR TITLE
Improvements in segment plotting

### DIFF
--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -1054,14 +1054,18 @@ class Segment:
                                              if f"{instr}_{ch}" in qb_chs}
                                     for qbi, qb_name in match.items():
                                         ax[qbi, 0].set_title(qb_name)
-                                        ax[qbi, 0].plot(tvals * 1e6, wf,
-                                                      label=f"{elem_name[1]}_{k}_{ch}",
-                                                      **plot_kwargs)
+                                        ax[qbi, 0].plot(
+                                            tvals * 1e6, wf,
+                                            label=f"{elem_name[1]}"
+                                                  f"_{k}_{instr}_{ch}",
+                                            **plot_kwargs)
                                         if demodulate: # filling
-                                            ax[qbi, 0].fill_between(tvals * 1e6, wf,
-                                                            label=f"{elem_name[1]}_{k}_{ch}",
-                                                            alpha=0.05,
-                                                            **plot_kwargs)
+                                            ax[qbi, 0].fill_between(
+                                                tvals * 1e6, wf,
+                                                label=f"{elem_name[1]}_"
+                                                      f"{k}_{instr}_{ch}",
+                                                alpha=0.05,
+                                                **plot_kwargs)
 
 
             # formatting

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -1081,7 +1081,7 @@ class Segment:
                     a.legend(loc=[1.02, 0], prop={'size': 8})
                 a.set_ylabel('Voltage (V)')
             ax[-1, 0].set_xlabel('time ($\mu$s)')
-            fig.suptitle(f'{self.name}')
+            fig.suptitle(f'{self.name}', y=1.01)
             plt.tight_layout()
             if savefig:
                 plt.savefig(f'{self.name}.png')

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -1041,16 +1041,19 @@ class Segment:
                                     f"{instr}_{ch}"] - delays.get(instr, 0)
                                 if channel_map is None:
                                     # plot per device
+                                    ax[i, 0].set_title(instr)
                                     ax[i, 0].plot(tvals * 1e6, wf,
                                                   label=f"{elem_name[1]}_{k}_{ch}",
                                                   **plot_kwargs)
                                 else:
                                     # plot on each qubit subplot which includes
                                     # this channel in the channel map
-                                    match = [i for i, (_, qb_chs) in
-                                                     enumerate(channel_map.items())
-                                                     if f"{instr}_{ch}" in qb_chs]
-                                    for qbi in match:
+                                    match = {i: qb_name
+                                             for i, (qb_name, qb_chs) in
+                                             enumerate(channel_map.items())
+                                             if f"{instr}_{ch}" in qb_chs}
+                                    for qbi, qb_name in match.items():
+                                        ax[qbi, 0].set_title(qb_name)
                                         ax[qbi, 0].plot(tvals * 1e6, wf,
                                                       label=f"{elem_name[1]}_{k}_{ch}",
                                                       **plot_kwargs)

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -975,24 +975,24 @@ class Segment:
              channel_map=None, plot_kwargs=None, axes=None, demodulate=False):
         """
         Plots a segment. Can only be done if the segment can be resolved.
-        :param instruments (list): instruments for which pulses have to be plotted.
-            defaults to all.
+        :param instruments (list): instruments for which pulses have to be
+            plotted. Defaults to all.
         :param channels (list):  channels to plot. defaults to all.
-        :param delays (dict): keys are instruments, values are additional delays.
-            if passed, the delay is substracted to the time values of this
-            instrument, such that the pulses are plotted at timing when they
-            physically occur.
+        :param delays (dict): keys are instruments, values are additional
+            delays. If passed, the delay is substracted to the time values of
+            this instrument, such that the pulses are plotted at timing when
+            they physically occur.
         :param savefig: save the plot
-        :param channel_map (dict): indicates which instrument channels correspond to
-            whichqubits. Keys = qb names, values = list of channels. eg.
-            dict(qb2=['AWG8_ch3', "UHF_ch1"]). If provided, will plot each qubit
-            on individual subplots.
+        :param channel_map (dict): indicates which instrument channels
+            correspond to which qubits. Keys = qb names, values = list of
+            channels. eg. dict(qb2=['AWG8_ch3', "UHF_ch1"]). If provided,
+            will plot each qubit on individual subplots.
         :param prop_cycle (dict):
         :param frameon (dict, bool):
-        :param axes (array or axis): 2D array of matplotlib axes. if single axes,
-            will be converted internally to array.
-        :param demodulate (bool): plot only envelope of pulses by temporarily setting
-            modulation and phase to 0. Need to recompile the sequence
+        :param axes (array or axis): 2D array of matplotlib axes. if single
+            axes, will be converted internally to array.
+        :param demodulate (bool): plot only envelope of pulses by temporarily
+            setting modulation and phase to 0. Need to recompile the sequence
         :return:
         """
         import matplotlib.pyplot as plt
@@ -1012,7 +1012,8 @@ class Segment:
                         if hasattr(pulse, "phase"):
                             pulse.phase = 0
             wfs = self.waveforms(awgs=instruments, channels=None)
-            n_instruments = len(wfs) if channel_map is None else len(channel_map)
+            n_instruments = len(wfs) if channel_map is None else \
+                len(channel_map)
             if axes is not None:
                 if np.ndim(axes) == 0:
                     axes = [[axes]]
@@ -1042,9 +1043,10 @@ class Segment:
                                 if channel_map is None:
                                     # plot per device
                                     ax[i, 0].set_title(instr)
-                                    ax[i, 0].plot(tvals * 1e6, wf,
-                                                  label=f"{elem_name[1]}_{k}_{ch}",
-                                                  **plot_kwargs)
+                                    ax[i, 0].plot(
+                                        tvals * 1e6, wf,
+                                        label=f"{elem_name[1]}_{k}_{ch}",
+                                        **plot_kwargs)
                                 else:
                                     # plot on each qubit subplot which includes
                                     # this channel in the channel map
@@ -1067,9 +1069,8 @@ class Segment:
                                                 alpha=0.05,
                                                 **plot_kwargs)
 
-
             # formatting
-            for a in ax[:,0]:
+            for a in ax[:, 0]:
                 if isinstance(frameon, bool):
                     frameon = {k: frameon for k in ['top', 'bottom',
                                                     "right", "left"]}
@@ -1085,11 +1086,11 @@ class Segment:
             plt.tight_layout()
             if savefig:
                 plt.savefig(f'{self.name}.png')
-            # plt.show()
             return fig, ax
         except Exception as e:
             log.error(f"Could not plot: {self.name}")
             raise e
+
     def __repr__(self):
         string_repr = f"---- {self.name} ----\n"
 

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -1031,7 +1031,9 @@ class Segment:
                 # plotting
                 for elem_name, v in wfs[instr].items():
                     for k, wf_per_ch in v.items():
-                        for n_wf, (ch, wf) in enumerate(wf_per_ch.items()):
+                        sorted_chans = sorted(wf_per_ch.keys())
+                        for n_wf, ch in enumerate(sorted_chans):
+                            wf = wf_per_ch[ch]
                             if channels is None or \
                                     ch in channels.get(instr, []):
                                 tvals = \

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -1025,7 +1025,9 @@ class Segment:
             if prop_cycle is not None:
                 for a in ax[:,0]:
                     a.set_prop_cycle(**prop_cycle)
-            for i, instr in enumerate(wfs):
+            sorted_keys = sorted(wfs.keys()) if instruments is None \
+                else [i for i in instruments if i in wfs]
+            for i, instr in enumerate(sorted_keys):
                 # plotting
                 for elem_name, v in wfs[instr].items():
                     for k, wf_per_ch in v.items():

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -972,7 +972,8 @@ class Segment:
 
     def plot(self, instruments=None, channels=None, legend=True,
              delays=None, savefig=False, prop_cycle=None, frameon=True,
-             channel_map=None, plot_kwargs=None, axes=None, demodulate=False):
+             channel_map=None, plot_kwargs=None, axes=None, demodulate=False,
+             show_and_close=True):
         """
         Plots a segment. Can only be done if the segment can be resolved.
         :param instruments (list): instruments for which pulses have to be
@@ -993,7 +994,9 @@ class Segment:
             axes, will be converted internally to array.
         :param demodulate (bool): plot only envelope of pulses by temporarily
             setting modulation and phase to 0. Need to recompile the sequence
-        :return:
+        :param show_and_close: (bool) show and close the plot (default: True)
+        :return: The figure and axes objects if show_and_close is False,
+            otherwise no return value.
         """
         import matplotlib.pyplot as plt
         if delays is None:
@@ -1086,7 +1089,12 @@ class Segment:
             plt.tight_layout()
             if savefig:
                 plt.savefig(f'{self.name}.png')
-            return fig, ax
+            if show_and_close:
+                plt.show()
+                plt.close(fig)
+                return
+            else:
+                return fig, ax
         except Exception as e:
             log.error(f"Could not plot: {self.name}")
             raise e

--- a/pycqed/measurement/waveform_control/sequence.py
+++ b/pycqed/measurement/waveform_control/sequence.py
@@ -330,11 +330,13 @@ class Sequence:
                 setattr(new_seq, k, deepcopy(v, memo))
         return new_seq
 
-    def plot(self, segments=None, **segment_plot_kwargs):
+    def plot(self, segments=None, show_and_close=True, **segment_plot_kwargs):
         """
         :param segments: list of segment names to plot
+        :param show_and_close: (bool) show and close the plots (default: True)
         :param segment_plot_kwargs:
-        :return:
+        :return: A list of tuples of figure and axes objects if show_and_close
+            is False, otherwise no return value.
         """
         plots = []
         if segments is None:
@@ -342,5 +344,9 @@ class Sequence:
         else:
             segments = [self.segments[s] for s in segments]
         for s in segments:
-            plots.append(s.plot(**segment_plot_kwargs))
-        return plots
+            plots.append(s.plot(show_and_close=show_and_close,
+                                **segment_plot_kwargs))
+        if show_and_close:
+            return
+        else:
+            return plots


### PR DESCRIPTION
Various improvements in segment plotting:
- sort plots by instrument names (or by order in instruments if instruments is provided)
- sort lines in plots by channel names
- add instrument/qubit name as subplot title
- add AWG name to legend entry when plotting per qubit
- corrected position of figure title 

Tested on a virtual setup (and partially on XLD).

FYI @antsr 