### PR TITLE
Bugfixes fo the analysis daemon

### DIFF
--- a/pycqed/analysis_v2/analysis_daemon.py
+++ b/pycqed/analysis_v2/analysis_daemon.py
@@ -60,9 +60,9 @@ class AnalysisDaemon:
     def run(self):
         try:
             while (True):
-                self.check_job()
-                for i in range(self.poll_interval):
-                    time.sleep(1)
+                if not self.check_job():
+                    for i in range(self.poll_interval):
+                        time.sleep(1)
         except KeyboardInterrupt as e:
             pass
         except Exception as e:
@@ -73,7 +73,8 @@ class AnalysisDaemon:
     def check_job(self):
         """
         Checks whether new jobs have been found and processes them
-        Returns:
+        Returns: True is a job was found and processed (done or failed),
+            False otherwise.
 
         """
         try:
@@ -103,19 +104,30 @@ class AnalysisDaemon:
                     os.rename(filename, filename + '.running')
                     self.run_job(job)
                     time.sleep(1)  # wait to make sure that files are written
+                    t = self.get_datetimestamp()
                     if os.path.isfile(filename):
-                        os.rename(filename, filename + '.loop_detected')
+                        os.rename(filename,
+                                  f"{filename}_{t}.loop_detected")
                         log.warning(f'A loop was detected! Job {filename} '
                                     f'tries to delegate plotting.')
-                    if errl == len(self.errs):
-                        os.rename(filename + '.running', filename + '.done')
+                    if errl == len(self.job_errs):
+                        os.rename(filename + '.running',
+                                  f"{filename}_{t}.done")
                     else:
-                        os.rename(filename + '.running', filename + '.failed')
-                        new_errors = self.errs[errl:]
-                        self.write_to_job(filename + '.failed', new_errors)
+                        new_filename = f"{filename}_{t}.failed"
+                        os.rename(filename + '.running', new_filename)
+                        new_errors = self.job_errs[errl:]
+                        self.write_to_job(new_filename, new_errors)
                     self.last_ts = ts
         if not found_jobs:
             log.info(f"No new job found.")
+            return False
+        else:
+            return True
+
+    @staticmethod
+    def get_datetimestamp():
+        return time.strftime('%Y%m%d_%H%M%S', time.localtime())
 
     @staticmethod
     def read_job(filename):
@@ -123,10 +135,11 @@ class AnalysisDaemon:
         job = "".join(job_file.readlines())
         job_file.close()
         return job
+
     @staticmethod
     def write_to_job(filename, new_lines):
-        job_file = open(filename, 'r+')
-        job_file.write("\n")
+        job_file = open(filename, 'a+')
+        job_file.write("\n\n")
         job_file.write("".join(new_lines))
         job_file.close()
 

--- a/pycqed/analysis_v2/analysis_daemon.py
+++ b/pycqed/analysis_v2/analysis_daemon.py
@@ -73,7 +73,7 @@ class AnalysisDaemon:
     def check_job(self):
         """
         Checks whether new jobs have been found and processes them
-        Returns: True is a job was found and processed (done or failed),
+        Returns: True if a job was found and processed (done or failed),
             False otherwise.
 
         """

--- a/pycqed/analysis_v2/analysis_daemon.py
+++ b/pycqed/analysis_v2/analysis_daemon.py
@@ -100,11 +100,17 @@ class AnalysisDaemon:
 
                     job = self.read_job(filename)
                     errl = len(self.job_errs)
+                    os.rename(filename, filename + '.running')
                     self.run_job(job)
+                    time.sleep(1)  # wait to make sure that files are written
+                    if os.path.isfile(filename):
+                        os.rename(filename, filename + '.loop_detected')
+                        log.warning(f'A loop was detected! Job {filename} '
+                                    f'tries to delegate plotting.')
                     if errl == len(self.errs):
-                        os.rename(filename, filename + '.done')
+                        os.rename(filename + '.running', filename + '.done')
                     else:
-                        os.rename(filename, filename + '.failed')
+                        os.rename(filename + '.running', filename + '.failed')
                         new_errors = self.errs[errl:]
                         self.write_to_job(filename + '.failed', new_errors)
                     self.last_ts = ts

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -234,12 +234,13 @@ class BaseDataAnalysis(object):
         """
         sep = ', ' if len(args) > 0 else ""
         class_name = self.__class__.__name__
+        kwargs = copy.copy(kwargs)
 
         # prevent the job from calling itself in a loop
         options_dict = copy.deepcopy(kwargs.get('options_dict', {}))
         if options_dict is None:
             options_dict = {}
-        options_dict.pop('delegate_plotting', None)
+        options_dict['delegate_plotting'] = False
         kwargs['options_dict'] = options_dict
 
         # prepare import


### PR DESCRIPTION
- in base_analysis: avoid infinite loop if delegate_plotting is in metadata
- in the daemon: detect and break infinite loops
- correctly distinguish between errors in and outside jobs
- add a timestamp after processing a job file
- directly check for next job after finishing a job
- append error messages at the end of the jobfile (instead of overwriting the content)

Tested on S17

FYI @antsr 
