### PR TITLE
Enhancements in SSRO analysis

### DIFF
--- a/pycqed/analysis_v2/readout_analysis.py
+++ b/pycqed/analysis_v2/readout_analysis.py
@@ -954,7 +954,8 @@ class Singleshot_Readout_Analysis_Qutrit(ba.BaseDataAnalysis):
     def plot_fidelity_matrix(fm, target_names,
                              title="State Assignment Probability Matrix",
                              auto_shot_info=True, ax=None,
-                             cmap=None, normalize=True, show=False):
+                             cmap=None, normalize=True, show=False,
+                             plot_cb=True):
         fidelity_avg = np.trace(fm) / float(np.sum(fm))
         if auto_shot_info:
             title += '\nTotal # shots:{}'.format(np.sum(fm))
@@ -972,8 +973,9 @@ class Singleshot_Readout_Analysis_Qutrit(ba.BaseDataAnalysis):
         im = ax.imshow(fm, interpolation='nearest', cmap=cmap,
                        norm=mc.LogNorm(), vmin=5e-3, vmax=1.)
         ax.set_title(title)
-        cb = fig.colorbar(im)
-        cb.set_label('Assignment Probability, $P_{ij}$')
+        if plot_cb:
+            cb = fig.colorbar(im)
+            cb.set_label('Assignment Probability, $P_{ij}$')
 
         if target_names is not None:
             tick_marks = np.arange(len(target_names))

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -6295,16 +6295,26 @@ class MultiQutrit_Singleshot_Readout_Analysis(MultiQubit_TimeDomain_Analysis):
                     # plot means and std dev
                     means = pdd['analysis_params']['means'][qbn]
                     try:
+                        clf_means = pdd['analysis_params'][
+                            'classifier_params'][qbn]['means_']
+                    except Exception as e: # not a gmm model--> no clf_means.
+                        clf_means = []
+                    try:
                         covs = self._get_covariances(self.clf_[qbn])
                     except Exception as e: # not a gmm model--> no cov.
                         covs = []
 
                     for i, mean in enumerate(means.values()):
                         main_ax.scatter(mean[0], mean[1], color='w', s=80)
+                        if len(clf_means):
+                            main_ax.scatter(clf_means[i][0], clf_means[i][1],
+                                                      color='k', s=80)
                         if len(covs) != 0:
-                            self.plot_std(mean, covs[i],
+                            self.plot_std(clf_means[i] if len(clf_means)
+                                          else mean,
+                                          covs[i],
                                           n_std=1, ax=main_ax,
-                                          edgecolor='w', linestyle='--',
+                                          edgecolor='k', linestyle='--',
                                           linewidth=1)
 
                 # plot thresholds and mapping

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -6125,6 +6125,7 @@ class MultiQutrit_Singleshot_Readout_Analysis(MultiQubit_TimeDomain_Analysis):
             gm = GM(n_components=n_qb_states,
                     covariance_type=cov_type,
                     random_state=0,
+                    weights_init=[1 / n_qb_states] * n_qb_states,
                     means_init=[mu for _, mu in
                                 self.proc_data_dict['analysis_params']
                                     ['means'][qb_name].items()])


### PR DESCRIPTION
- SSRO Analysis Qutrit: added optional argument plot_cb in plot_fidelity_matrix to switch off the colorbar (can be useful when calling the function from a notebook to manually create special versions of the plot e.g., with subfigures for multiple qubits)
- MultiQutrit_Singleshot_Readout_Analysis: use uniform initialization of gmm weights
- MultiQutrit_Singleshot_Readout_Analysis: plot gmm means (if available) in addition to cluster means

FYI @stephlazar @antsr 