### PR TITLE
Wrong default value for cal_points in BaseAnalysis

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -544,8 +544,7 @@ class BaseDataAnalysis(object):
                 self.raw_data_dict['exp_metadata'] = {}
             self.metadata = self.raw_data_dict['exp_metadata']
             cp = CalibrationPoints.from_string(self.get_param_value(
-                'cal_points', default_value=
-                CalibrationPoints.from_string(repr(CalibrationPoints([], [])))))
+                'cal_points', default_value=repr(CalibrationPoints([], []))))
             self.raw_data_dict = self.add_measured_data(
                 self.raw_data_dict,
                 self.get_param_value('compression_factor', 1),


### PR DESCRIPTION
Fixes bug in BaseDataAnalysis.extract_data(): wrong default value when extracting CalibrationPoints.

FYI @antsr I took the fix from the feature/tracker_analysis branch.




