### PR TITLE
Proper fix to extracting cal_points in BaseDataAnalysis.extract_data().

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -543,8 +543,11 @@ class BaseDataAnalysis(object):
             if len(self.raw_data_dict['exp_metadata']) == 0:
                 self.raw_data_dict['exp_metadata'] = {}
             self.metadata = self.raw_data_dict['exp_metadata']
-            cp = CalibrationPoints.from_string(self.get_param_value(
-                'cal_points', default_value=repr(CalibrationPoints([], []))))
+            try:
+                cp = CalibrationPoints.from_string(self.get_param_value(
+                    'cal_points'))
+            except TypeError:
+                cp = CalibrationPoints([], [])
             self.raw_data_dict = self.add_measured_data(
                 self.raw_data_dict,
                 self.get_param_value('compression_factor', 1),


### PR DESCRIPTION
Turns out the version in Proj/S17 was the correct one, not the one in the spec_tracker branch (which broke anything calling MultiQubit_SingleShot_Analysis with the very old style cal_points).


