### PR TITLE
Correct normalization of calibration matrix in MultiQubit_SingleShot_Analysis

### DIFF
--- a/pycqed/analysis_v2/readout_analysis.py
+++ b/pycqed/analysis_v2/readout_analysis.py
@@ -1808,6 +1808,7 @@ class MultiQubit_SingleShot_Analysis(ba.BaseDataAnalysis):
             val_list = [self.proc_data_dict['probability_table'][idx_ro]
                         [observabele_idxs] for idx_ro in cal_point[0]]
             means[i] = np.mean(val_list, axis=0)
+            means[i] /= means[i].sum()
 
         # find the means for all the products of the operators and the average
         # covariation of the operators


### PR DESCRIPTION
Adds by-row normalization for the calibration state assignment matrix in MultiQubit_SingleShot_Analysis.calibration_point_means_and_channel_covariations. This is used when calculating the measurement ops for state tomography analysis

