### PR TITLE
Store metadata created by detector functions

### DIFF
--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -44,9 +44,18 @@ class Detector_Function(object):
         pass
 
     def generate_metadata(self):
+        """
+        Creates a dict det_metadata with all the attributes of itself.
+        :return: {'Detector Metadata': det_metadata}
+        """
+
+        # Go through all the attributes of itself, pass them to
+        # savable_attribute_value, and store them in det_metadata
         det_metadata = {k: self.savable_attribute_value(v, self.name)
                         for k, v in self.__dict__.items()}
 
+        # Change the 'detectors' entry from a list of dicts to a dict with keys
+        # uhfName_detectorName
         detectors_dict = {}
         for d in det_metadata.pop('detectors', []):
             detectors_dict.update({f'{d["UHFs"][0]} {d["name"]}': d})
@@ -57,6 +66,27 @@ class Detector_Function(object):
 
     @staticmethod
     def savable_attribute_value(attr_val, det_name):
+        """
+        Helper function for converting the attribute of a Detector_Function
+        (or its children) to a format that will make the entry more meaningful
+        when saved to an hdf file.
+        In particular,  this function makes sure that if any of the det_func
+        attributes are class instances (like det_func.AWG), they are passed to
+        the metadata as class_instance.name instead of class_instance, in which
+        case it would be saves as a string "<Pulsar: Pulsar>".
+        This function also nicely resolves the detectors attribute of the
+        detector functions, which would otherwise also be saved as
+        ["<pycqed.measurement.detector_functions.UHFQC_classifier_detector
+         at 0x22bf280a400>",
+         "<pycqed.measurement.detector_functions.UHFQC_classifier_detector
+         at 0x22bf280a208>"].
+
+        :param attr_val: attribute value of a Detector_Function instance or
+            an instance of its children
+        :param det_name: name of a Detector_Function instance or an instance
+            of its children
+        :return: converted attribute value
+        """
         if isinstance(attr_val, Detector_Function):
             if hasattr(attr_val, 'detectors') and \
                     det_name != attr_val.detectors[0].name:

--- a/pycqed/measurement/measurement_control.py
+++ b/pycqed/measurement/measurement_control.py
@@ -188,8 +188,11 @@ class MeasurementControl(Instrument):
 
         with h5d.Data(name=self.get_measurement_name(),
                       datadir=self.datadir()) as self.data_object:
+            self.exp_metadata = self.detector_function.generate_metadata()
             if exp_metadata is not None:
-                self.save_exp_metadata(exp_metadata, self.data_object)
+                self.exp_metadata.update(exp_metadata)
+            self.save_exp_metadata(self.exp_metadata, self.data_object)
+
             try:
                 self.check_keyboard_interrupt()
                 self.get_measurement_begintime()


### PR DESCRIPTION
Changes proposed in this pull request:

- adds the methods generate_metadata and savable_attribute_value to Detector_Function base class for all the detector in PycQED.
- adds the detector function metadata information to MC.exp_metadata and hence, saves it in the HDF file.

This is what the HDF file looks like for a 17 qubit ssro calibration measurement:
![image](https://user-images.githubusercontent.com/14844492/94004879-a8171800-fd9d-11ea-947b-d5eb8876ac0c.png)

And for a 9-qubit Rabi:
![image](https://user-images.githubusercontent.com/14844492/94004936-c1b85f80-fd9d-11ea-8302-4bd7850dd052.png)

Below I compared the time needed to create MC.exp_metadata and dump it into the data file, with and without the new detector metadata:
# 17-qubit ssro
0.015 # with det metadata
0.004 # without

# 9-qubit rabi
0.042 # with det metadata
0.023 # without

While indeed it takes slightly longer with the new feature, it is not limiting us compared to other waiting times like waveform generate or upload .

Fixes issue #45.

@chellings @nathlacroix FYI



