### PR TITLE
Add cast_init to SweepPoints and use it in analysis_v2

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -551,7 +551,7 @@ class BaseDataAnalysis(object):
             self.raw_data_dict = self.add_measured_data(
                 self.raw_data_dict,
                 self.get_param_value('compression_factor', 1),
-                self.get_param_value('sweep_points'),
+                SweepPoints.cast_init(self.get_param_value('sweep_points')),
                 cp, self.get_param_value('preparation_params',
                                          default_value=dict()))
         else:

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -251,7 +251,7 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
     def get_sweep_points(self):
         self.sp = self.get_param_value('sweep_points')
         if self.sp is not None:
-            self.sp = SweepPoints(from_dict_list=self.sp)
+            self.sp = SweepPoints.cast_init(self.sp)
 
     def create_sweep_points_dict(self):
         sweep_points_dict = self.get_param_value('sweep_points_dict')

--- a/pycqed/measurement/sweep_points.py
+++ b/pycqed/measurement/sweep_points.py
@@ -2,6 +2,7 @@ import logging
 log = logging.getLogger(__name__)
 from collections import OrderedDict
 from copy import deepcopy
+from numpy import array  # Needed for eval. Do not remove.
 
 class SweepPoints(list):
     """
@@ -302,3 +303,18 @@ class SweepPoints(list):
             if param_name in self[dim]:
                 return dim
         return None
+
+    @staticmethod
+    def cast_init(sweep_points):
+        """
+        Recreates a SweepPoints object from a string representation.
+        Avoids having "eval" statements throughout the codebase.
+        Args:
+            sweep_points_string: string representation of the SweepPoints
+
+        Returns: SweepPoints object
+        """
+        if isinstance(sweep_points, str):
+            return SweepPoints(from_dict_list=eval(sweep_points))
+        else:
+            return SweepPoints(from_dict_list=sweep_points)

--- a/pycqed/measurement/sweep_points.py
+++ b/pycqed/measurement/sweep_points.py
@@ -307,10 +307,12 @@ class SweepPoints(list):
     @staticmethod
     def cast_init(sweep_points):
         """
-        Recreates a SweepPoints object from a string representation.
+        Recreates a SweepPoints object from a string representation of
+            SweepPoints, or a list of dicts.
         Avoids having "eval" statements throughout the codebase.
         Args:
-            sweep_points_string: string representation of the SweepPoints
+            sweep_points: string representation of the SweepPoints or
+                a list of dicts
 
         Returns: SweepPoints object
         """


### PR DESCRIPTION
cast_init recreates a SweepPoints object from a string representation of SweepPoints, or a list of dicts.
Avoids having "eval" statements throughout the codebase.

From S17


