### PR TITLE
Proper data extraction for 2D ssro measurement

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -441,9 +441,13 @@ class BaseDataAnalysis(object):
             # run in 1D mode (so only 1 column of sweep points in hdf5 file)
             # CURRENTLY ONLY WORKS WITH SweepPoints CLASS INSTANCES
             hybrid_measurement = False
+            raw_data_dict['hard_sweep_points'] = np.unique(mc_points[0])
             if mc_points.shape[0] > 1:
                 hsp = np.unique(mc_points[0])
-                ssp = np.unique(mc_points[1:])
+                ssp, counts = np.unique(mc_points[1:], return_counts=True)
+                if counts[0] != len(hsp):
+                    # ssro data
+                    hsp = np.tile(hsp, counts[0]//len(hsp))
                 # if needed, decompress the data (assumes hsp and ssp are indices)
                 if compression_factor != 1:
                     hsp = hsp[:int(len(hsp) / compression_factor)]
@@ -471,8 +475,6 @@ class BaseDataAnalysis(object):
                     ssp = np.arange(len(dim_2_sp))
                     raw_data_dict['hard_sweep_points'] = hsp
                     raw_data_dict['soft_sweep_points'] = ssp
-            else:
-                raw_data_dict['hard_sweep_points'] = np.unique(mc_points[0])
 
             data = measured_data[-len(value_names):]
             if data.shape[0] != len(value_names):

--- a/pycqed/analysis_v2/readout_analysis.py
+++ b/pycqed/analysis_v2/readout_analysis.py
@@ -1542,7 +1542,7 @@ class MultiQubit_SingleShot_Analysis(ba.BaseDataAnalysis):
         if self.thresholds is not None:
             for qubit, channel in self.channel_map.items():
                 shots_cont = np.array(
-                    self.raw_data_dict['measured_data'][channel])
+                    self.raw_data_dict['measured_data'][channel]).T.flatten()
                 shots_thresh[qubit] = (shots_cont > self.thresholds[qubit])
             self.proc_data_dict['shots_thresholded'] = shots_thresh
         else:


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes BaseDataAnalysis.add_measured_data() to do the correct thing for an ssro data set.
- Fixes correct line in MultiQubit_SingleShot_Analysis.process_data() to work for 2D ssro data set.

Has been used for some times with no issues on XLD setup in the branch Proj/S17..


