### PR TITLE
Proper handling of qutip objects when writing to HDF file

### DIFF
--- a/pycqed/measurement/hdf5_data.py
+++ b/pycqed/measurement/hdf5_data.py
@@ -13,10 +13,17 @@ Contains:
 import os
 import time
 import h5py
-import qutip
 import numpy as np
 import logging
 log = logging.getLogger(__name__)
+
+try:
+    import qutip
+    qutip_imported = True
+except Exception:
+    log.warning('qutip was not imported. qutip objects will be stored as '
+                'strings.')
+    qutip_imported = False
 
 
 class DateTimeGenerator:
@@ -154,8 +161,9 @@ def write_dict_to_hdf5(data_dict: dict, entry_point, overwrite=False):
                 log.error(e)
                 log.error('Exception occurred while writing'
                       ' {}:{} of type {}'.format(key, item, type(item)))
-        elif isinstance(item, (np.ndarray, qutip.qobj.Qobj)):
-            if isinstance(item, qutip.qobj.Qobj):
+        elif isinstance(item, np.ndarray) or (
+            qutip_imported and isinstance(item, qutip.qobj.Qobj)):
+            if qutip_imported and isinstance(item, qutip.qobj.Qobj):
                 item = item.full()
             try:
                 entry_point.create_dataset(key, data=item)

--- a/pycqed/measurement/hdf5_data.py
+++ b/pycqed/measurement/hdf5_data.py
@@ -162,7 +162,7 @@ def write_dict_to_hdf5(data_dict: dict, entry_point, overwrite=False):
                 log.error('Exception occurred while writing'
                       ' {}:{} of type {}'.format(key, item, type(item)))
         elif isinstance(item, np.ndarray) or (
-            qutip_imported and isinstance(item, qutip.qobj.Qobj)):
+                qutip_imported and isinstance(item, qutip.qobj.Qobj)):
             if qutip_imported and isinstance(item, qutip.qobj.Qobj):
                 item = item.full()
             try:

--- a/pycqed/measurement/hdf5_data.py
+++ b/pycqed/measurement/hdf5_data.py
@@ -158,8 +158,6 @@ def write_dict_to_hdf5(data_dict: dict, entry_point, overwrite=False):
             if isinstance(item, qutip.qobj.Qobj):
                 item = item.full()
             try:
-                print()
-                print(key)
                 entry_point.create_dataset(key, data=item)
             except RuntimeError:
                 if overwrite:

--- a/pycqed/measurement/hdf5_data.py
+++ b/pycqed/measurement/hdf5_data.py
@@ -13,6 +13,7 @@ Contains:
 import os
 import time
 import h5py
+import qutip
 import numpy as np
 import logging
 log = logging.getLogger(__name__)
@@ -153,8 +154,12 @@ def write_dict_to_hdf5(data_dict: dict, entry_point, overwrite=False):
                 log.error(e)
                 log.error('Exception occurred while writing'
                       ' {}:{} of type {}'.format(key, item, type(item)))
-        elif isinstance(item, np.ndarray):
+        elif isinstance(item, (np.ndarray, qutip.qobj.Qobj)):
+            if isinstance(item, qutip.qobj.Qobj):
+                item = item.full()
             try:
+                print()
+                print(key)
                 entry_point.create_dataset(key, data=item)
             except RuntimeError:
                 if overwrite:
@@ -162,7 +167,6 @@ def write_dict_to_hdf5(data_dict: dict, entry_point, overwrite=False):
                     entry_point.create_dataset(key, data=item)
                 else:
                     raise
-
         elif item is None:
             # as h5py does not support saving None as attribute
             # I create special string, note that this can create


### PR DESCRIPTION
Changes proposed in this pull request:

- modifies hdf5_data.py/write_dict_to_hdf5 to check for qutip objects and save them as datasets



