### PR TITLE
fix enforce_single_element for pulses that span multiple awg-s

### DIFF
--- a/pycqed/measurement/waveform_control/pulse.py
+++ b/pycqed/measurement/waveform_control/pulse.py
@@ -79,6 +79,13 @@ class Pulse:
                     wfs_dict[c] = np.zeros_like(wfs_dict[c])
         return wfs_dict
 
+    def masked_channels(self):
+        channel_mask = getattr(self, 'channel_mask', None)
+        if channel_mask is None:
+            return self.channels
+        else:
+            return [ch for m, ch in zip(channel_mask, self.channels) if m]
+
     def pulse_area(self, channel, tvals):
         """
         Calculates the area of a pulse on the given channel and time-interval.

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -132,13 +132,35 @@ class Segment:
         self.add_charge_compensation()
 
     def enforce_single_element(self):
-        self.resolved_pulses = deepcopy(self.unresolved_pulses)
-        for p in self.resolved_pulses:
+        self.resolved_pulses = []
+        for p in self.unresolved_pulses:
+            ch_mask = []
             for ch in p.pulse_obj.channels:
                 ch_awg = self.pulsar.get(f'{ch}_awg')
-                if self.pulsar.get(f'{ch_awg}_enforce_single_element'):
-                    p.pulse_obj.element_name = f'default_{self.name}'
-                    break
+                ch_mask.append(
+                    self.pulsar.get(f'{ch_awg}_enforce_single_element'))
+            if all(ch_mask) and len(ch_mask) != 0:
+                p = deepcopy(p)
+                p.pulse_obj.element_name = f'default_{self.name}'
+                self.resolved_pulses.append(p)
+            elif any(ch_mask):
+                p0 = deepcopy(p)
+                p0.pulse_obj.channel_mask = [not x for x in ch_mask]
+                self.resolved_pulses.append(p0)
+
+                p1 = deepcopy(p)
+                p1.pulse_obj.element_name = f'default_{self.name}'
+                p1.pulse_obj.channel_mask = ch_mask
+                p1.ref_pulse = p.pulse_obj.name
+                p1.ref_point = 0
+                p1.ref_point_new = 0
+                p1.basis_rotation = {}
+                p1.delay = 0
+                p1.pulse_obj.name += '_ese'
+                self.resolved_pulses.append(p1)
+            else:
+                p = deepcopy(p)
+                self.resolved_pulses.append(p)
 
     def resolve_timing(self, resolve_block_align=True):
         """
@@ -312,7 +334,7 @@ class Segment:
                 # Find the end of the last pulse of the segment
                 t_end = max(t_end, pulse.algorithm_time() + pulse.length)
 
-                for c in pulse.channels:
+                for c in pulse.masked_channels():
                     if c not in compensation_chan:
                         continue
                     awg = self.pulsar.get('{}_awg'.format(c))
@@ -436,7 +458,7 @@ class Segment:
 
         for element in self.elements:
             for pulse in self.elements[element]:
-                for channel in pulse.channels:
+                for channel in pulse.masked_channels():
                     awg = self.pulsar.get(channel + '_awg')
                     if awg in self.elements_on_awg and \
                         element not in self.elements_on_awg[awg]:
@@ -716,6 +738,11 @@ class Segment:
         t_end = -float('inf')
 
         for pulse in self.elements[element]:
+            for ch in pulse.masked_channels():
+                if self.pulsar.get(f'{ch}_awg') == awg:
+                    break
+            else:
+                continue
             t_start = min(pulse.algorithm_time(), t_start)
             t_end = max(pulse.algorithm_time() + pulse.length, t_end)
 
@@ -785,7 +812,7 @@ class Segment:
                 element_start_time = self.get_element_start(element, awg)
                 for pulse in self.elements[element]:
                     # checks whether pulse is played on AWG
-                    pulse_channels = set(pulse.channels) & set(channel_list)
+                    pulse_channels = set(pulse.masked_channels()) & set(channel_list)
                     if pulse_channels == set():
                         continue
                     if codewords is not None and \
@@ -908,7 +935,7 @@ class Segment:
         if awg is not None:
             channels = set(self.pulsar.find_awg_channels(awg))
         for pulse in self.elements[element]:
-            if awg is not None and len(set(pulse.channels) & channels) == 0:
+            if awg is not None and len(set(pulse.masked_channels()) & channels) == 0:
                 continue
             codewords.add(pulse.codeword)
         return codewords
@@ -919,9 +946,9 @@ class Segment:
             awg_channels = set(self.pulsar.find_awg_channels(awg))
         for pulse in self.elements[element]:
             if awg is not None:
-                channels |= set(pulse.channels) & awg_channels
+                channels |= set(pulse.masked_channels()) & awg_channels
             else:
-                channels |= set(pulse.channels)
+                channels |= set(pulse.masked_channels())
         return channels
 
     def calculate_hash(self, elname, codeword, channel):


### PR DESCRIPTION
This pull request:
- adds option to mask away pulse channels in waveform generation
- ignore pulses on other awg-s when calculating element length on awg 
- fix enforce_single_element for pulses that span multiple awg-s

Tested on S17

FYI @stephlazar 