### PR TITLE
store the programmed awg_source_string in the AWG object

### DIFF
--- a/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
+++ b/pycqed/instrument_drivers/physical_instruments/ZurichInstruments/ZI_base_instrument.py
@@ -612,6 +612,8 @@ class ZI_base_instrument(Instrument):
         # Create other neat parameters
         self._add_extra_parameters()
 
+        self._awg_source_strings = {}
+
         # Structure for storing errors
         self._errors = None
         # Structure for storing errors that should be demoted to warnings
@@ -1251,6 +1253,9 @@ class ZI_base_instrument(Instrument):
 
         # Check that awg_nr is set in accordance with devtype
         self._check_awg_nr(awg_nr)
+
+        self._awg_source_strings[awg_nr] = program_string
+
 
         t0 = time.time()
         success_and_ready = False


### PR DESCRIPTION
This is required for the save_bugreport function (see S17 init script)

Tested on S17