### PR TITLE
Analysis Error Handling

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -131,73 +131,77 @@ class BaseDataAnalysis(object):
         :param do_fitting: Should the run_fitting method be executed?
         '''
 
-        # initialize an empty dict to store results of analysis
-        self.proc_data_dict = OrderedDict()
-        if options_dict is None:
-            self.options_dict = OrderedDict()
-        else:
-            self.options_dict = options_dict
-
-        ################################################
-        # These options determine what data to extract #
-        ################################################
-        self.timestamps = None
-        if data_file_path is None:
-            if t_start is None:
-                if isinstance(label, list):
-                    self.timestamps = [a_tools.latest_data(
-                        contains=lab, return_timestamp=True)[0] for lab in label]
-                else:
-                    self.timestamps = [a_tools.latest_data(
-                        contains=label, return_timestamp=True)[0]]
-            elif t_stop is None:
-                if isinstance(t_start, list):
-                    self.timestamps = t_start
-                else:
-                    self.timestamps = [t_start]
+        try:
+            # initialize an empty dict to store results of analysis
+            self.proc_data_dict = OrderedDict()
+            if options_dict is None:
+                self.options_dict = OrderedDict()
             else:
-                self.timestamps = a_tools.get_timestamps_in_range(
-                    t_start, timestamp_end=t_stop,
-                    label=label if label != '' else None)
+                self.options_dict = options_dict
 
-        if self.timestamps is None or len(self.timestamps) == 0:
-            raise ValueError('No data file found.')
+            ################################################
+            # These options determine what data to extract #
+            ################################################
+            self.timestamps = None
+            if data_file_path is None:
+                if t_start is None:
+                    if isinstance(label, list):
+                        self.timestamps = [a_tools.latest_data(
+                            contains=lab, return_timestamp=True)[0] for lab in label]
+                    else:
+                        self.timestamps = [a_tools.latest_data(
+                            contains=label, return_timestamp=True)[0]]
+                elif t_stop is None:
+                    if isinstance(t_start, list):
+                        self.timestamps = t_start
+                    else:
+                        self.timestamps = [t_start]
+                else:
+                    self.timestamps = a_tools.get_timestamps_in_range(
+                        t_start, timestamp_end=t_stop,
+                        label=label if label != '' else None)
 
-
-        ########################################
-        # These options relate to the plotting #
-        ########################################
-        self.plot_dicts = OrderedDict()
-        self.axs = OrderedDict()
-        self.figs = OrderedDict()
-        self.presentation_mode = self.options_dict.get(
-            'presentation_mode', False)
-        self.do_individual_traces = self.options_dict.get(
-            'do_individual_traces', False)
-        self.tight_fig = self.options_dict.get('tight_fig', True)
-        # used in self.plot_text, here for future compatibility
-        self.fancy_box_props = dict(boxstyle='round', pad=.4,
-                                    facecolor='white', alpha=0.5)
-
-        self.options_dict['plot_init'] = self.options_dict.get('plot_init',
-                                                               False)
-        self.options_dict['save_figs'] = self.options_dict.get(
-            'save_figs', True)
-        self.options_dict['close_figs'] = self.options_dict.get(
-            'close_figs', close_figs)
+            if self.timestamps is None or len(self.timestamps) == 0:
+                raise ValueError('No data file found.')
 
 
-        ####################################################
-        # These options relate to what analysis to perform #
-        ####################################################
-        self.extract_only = extract_only
-        self.do_fitting = do_fitting
+            ########################################
+            # These options relate to the plotting #
+            ########################################
+            self.plot_dicts = OrderedDict()
+            self.axs = OrderedDict()
+            self.figs = OrderedDict()
+            self.presentation_mode = self.options_dict.get(
+                'presentation_mode', False)
+            self.do_individual_traces = self.options_dict.get(
+                'do_individual_traces', False)
+            self.tight_fig = self.options_dict.get('tight_fig', True)
+            # used in self.plot_text, here for future compatibility
+            self.fancy_box_props = dict(boxstyle='round', pad=.4,
+                                        facecolor='white', alpha=0.5)
 
-        self.verbose = self.options_dict.get('verbose', False)
-        self.auto_keys = self.options_dict.get('auto_keys', None)
+            self.options_dict['plot_init'] = self.options_dict.get('plot_init',
+                                                                   False)
+            self.options_dict['save_figs'] = self.options_dict.get(
+                'save_figs', True)
+            self.options_dict['close_figs'] = self.options_dict.get(
+                'close_figs', close_figs)
 
-        if type(self.auto_keys) is str:
-            self.auto_keys = [self.auto_keys]
+
+            ####################################################
+            # These options relate to what analysis to perform #
+            ####################################################
+            self.extract_only = extract_only
+            self.do_fitting = do_fitting
+
+            self.verbose = self.options_dict.get('verbose', False)
+            self.auto_keys = self.options_dict.get('auto_keys', None)
+
+            if type(self.auto_keys) is str:
+                self.auto_keys = [self.auto_keys]
+        except Exception:
+            log.warning("Unhandled error during init of analysis!")
+            log.warning(traceback.format_exc())
 
     def run_analysis(self):
         """

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -353,8 +353,9 @@ class BaseDataAnalysis(object):
         # multi timestamp with different metadata
         elif isinstance(self.metadata, (list, tuple)) and \
                 len(self.metadata) != 0:
-            return self.options_dict.get(param_name,
-                                         self.metadata[metadata_index].get(param_name, default_value))
+            return self.options_dict.get(
+                param_name,
+                self.metadata[metadata_index].get(param_name, default_value))
         # base case
         else:
             return self.options_dict.get(param_name, self.metadata.get(

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -27,6 +27,7 @@ from pycqed.measurement.hdf5_data import read_dict_from_hdf5
 from pycqed.measurement.sweep_points import SweepPoints
 from pycqed.measurement.calibration.calibration_points import CalibrationPoints
 import copy
+import traceback
 import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.StreamHandler())
@@ -203,23 +204,27 @@ class BaseDataAnalysis(object):
         This function is at the core of all analysis and defines the flow.
         This function is typically called after the __init__.
         """
-        self.extract_data()  # extract data specified in params dict
-        self.process_data()  # binning, filtering etc
-        if self.do_fitting:
-            self.prepare_fitting()  # set up fit_dicts
-            self.run_fitting()  # fitting to models
-            self.save_fit_results()
-            self.analyze_fit_results()  # analyzing the results of the fits
+        try:
+            self.extract_data()  # extract data specified in params dict
+            self.process_data()  # binning, filtering etc
+            if self.do_fitting:
+                self.prepare_fitting()  # set up fit_dicts
+                self.run_fitting()  # fitting to models
+                self.save_fit_results()
+                self.analyze_fit_results()  # analyzing the results of the fits
 
-        delegate_plotting = self.check_plotting_delegation()
-        if not delegate_plotting:
-            self.prepare_plots()  # specify default plots
-            if not self.extract_only:
-                self.plot(key_list='auto')  # make the plots
+            delegate_plotting = self.check_plotting_delegation()
+            if not delegate_plotting:
+                self.prepare_plots()  # specify default plots
+                if not self.extract_only:
+                    self.plot(key_list='auto')  # make the plots
 
-            if self.options_dict.get('save_figs', False):
-                self.save_figures(close_figs=self.options_dict.get(
-                    'close_figs', False))
+                if self.options_dict.get('save_figs', False):
+                    self.save_figures(close_figs=self.options_dict.get(
+                        'close_figs', False))
+        except Exception:
+            log.warning("Unhandled error during analysis!")
+            log.warning(traceback.format_exc())
 
     def create_job(self, *args, **kwargs):
         """

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -71,7 +71,8 @@ class BaseDataAnalysis(object):
     def __init__(self, t_start: str = None, t_stop: str = None,
                  label: str = '', data_file_path: str = None,
                  close_figs: bool = True, options_dict: dict = None,
-                 extract_only: bool = False, do_fitting: bool = False):
+                 extract_only: bool = False, do_fitting: bool = False,
+                 raise_exceptions: bool = False):
         '''
         This is the __init__ of the abstract base class.
         It is intended to be called at the start of the init of the child
@@ -129,9 +130,14 @@ class BaseDataAnalysis(object):
                                 -'exact_label_match'
         :param extract_only: Should we also do the plots?
         :param do_fitting: Should the run_fitting method be executed?
+        :param raise_exceptions (bool): whether or not exceptions encountered
+            in __init__() and in run_analysis() should be raised or only logged.
         '''
 
         try:
+            # set error-handling behavior
+            self.raise_exceptions = raise_exceptions
+
             # initialize an empty dict to store results of analysis
             self.proc_data_dict = OrderedDict()
             if options_dict is None:
@@ -164,7 +170,6 @@ class BaseDataAnalysis(object):
             if self.timestamps is None or len(self.timestamps) == 0:
                 raise ValueError('No data file found.')
 
-
             ########################################
             # These options relate to the plotting #
             ########################################
@@ -187,7 +192,6 @@ class BaseDataAnalysis(object):
             self.options_dict['close_figs'] = self.options_dict.get(
                 'close_figs', close_figs)
 
-
             ####################################################
             # These options relate to what analysis to perform #
             ####################################################
@@ -199,9 +203,13 @@ class BaseDataAnalysis(object):
 
             if type(self.auto_keys) is str:
                 self.auto_keys = [self.auto_keys]
-        except Exception:
-            log.warning("Unhandled error during init of analysis!")
-            log.warning(traceback.format_exc())
+
+        except Exception as e:
+            if self.raise_exceptions:
+                raise e
+            else:
+                log.error("Unhandled error during init of analysis!")
+                log.error(traceback.format_exc())
 
     def run_analysis(self):
         """
@@ -226,9 +234,12 @@ class BaseDataAnalysis(object):
                 if self.options_dict.get('save_figs', False):
                     self.save_figures(close_figs=self.options_dict.get(
                         'close_figs', False))
-        except Exception:
-            log.warning("Unhandled error during analysis!")
-            log.warning(traceback.format_exc())
+        except Exception as e:
+            if self.raise_exceptions:
+                raise e
+            else:
+                log.error("Unhandled error during analysis!")
+                log.error(traceback.format_exc())
 
     def create_job(self, *args, **kwargs):
         """
@@ -255,14 +266,18 @@ class BaseDataAnalysis(object):
         # prepare import
         import_lines = f"from {self.__module__} import {class_name}\n"
 
+        # set default error handling of analysis to raise exceptions, such
+        # that they are caught by the Daemon reading the jobs
+        if "raise_exception" not in kwargs:
+            kwargs['raise_exceptions'] = True
         # if timestamp wasn't specified, specify it for the job
-        if not "t_start" in kwargs or kwargs["t_start"] is None:
+        if "t_start" not in kwargs or kwargs["t_start"] is None:
             kwargs["t_start"] = self.timestamps[0]
-        if (not "t_stop" in kwargs or kwargs["t_stop"] is None) and \
+        if ("t_stop" not in kwargs or kwargs["t_stop"] is None) and \
                 len(self.timestamps) > 1:
             kwargs['t_stop'] = self.timestamps[-1]
         kwargs_list = [f'{k}={v if not isinstance(v, str) else repr(v)}'
-                          for k, v in kwargs.items()]
+                       for k, v in kwargs.items()]
 
         job_lines = f"{class_name}({', '.join(args)}{sep}{', '.join(kwargs_list)})"
         self.job = f"{import_lines}{job_lines}"
@@ -339,7 +354,7 @@ class BaseDataAnalysis(object):
         elif isinstance(self.metadata, (list, tuple)) and \
                 len(self.metadata) != 0:
             return self.options_dict.get(param_name,
-                self.metadata[metadata_index].get(param_name, default_value))
+                                         self.metadata[metadata_index].get(param_name, default_value))
         # base case
         else:
             return self.options_dict.get(param_name, self.metadata.get(
@@ -349,7 +364,7 @@ class BaseDataAnalysis(object):
         raw_data_dict = []
         for timestamp in self.timestamps:
             raw_data_dict_ts = OrderedDict([(param, []) for param in
-                                           self.params_dict])
+                                            self.params_dict])
 
             folder = a_tools.get_folder(timestamp)
             h5mode = self.options_dict.get('h5mode', 'r+')
@@ -457,7 +472,7 @@ class BaseDataAnalysis(object):
                 ssp, counts = np.unique(mc_points[1:], return_counts=True)
                 if counts[0] != len(hsp):
                     # ssro data
-                    hsp = np.tile(hsp, counts[0]//len(hsp))
+                    hsp = np.tile(hsp, counts[0] // len(hsp))
                 # if needed, decompress the data (assumes hsp and ssp are indices)
                 if compression_factor != 1:
                     hsp = hsp[:int(len(hsp) / compression_factor)]
@@ -475,7 +490,7 @@ class BaseDataAnalysis(object):
                     len_dim_1_sp = len(sp.get_sweep_params_property('values', 0))
                     if 'active' in prep_params.get('preparation_type', 'wait'):
                         reset_reps = prep_params.get('reset_reps', 1)
-                        len_dim_1_sp *= reset_reps+1
+                        len_dim_1_sp *= reset_reps + 1
                     elif "preselection" in prep_params.get('preparation_type',
                                                            'wait'):
                         len_dim_1_sp *= 2
@@ -502,7 +517,7 @@ class BaseDataAnalysis(object):
                         # segment, and reshape the remaining data based on the
                         # hard (1st dimension) and soft (1st dimension)
                         # sweep points
-                        data_no_cp = data[i][:len(data[i])-num_cal_segments]
+                        data_no_cp = data[i][:len(data[i]) - num_cal_segments]
                         measured_data = np.reshape(data_no_cp, (ssl, hsl)).T
                         if num_cal_segments > 0:
                             # add back ssl number of copies of the cal points
@@ -579,7 +594,6 @@ class BaseDataAnalysis(object):
                         rd_dict,
                         self.get_param_value('compression_factor', 1, i)))
             self.raw_data_dict = tuple(temp_dict_list)
-
 
     def process_data(self):
         """
@@ -824,7 +838,7 @@ class BaseDataAnalysis(object):
             key: key of the data to save. All processed data is saved by 
                  default.
         """
-        #default: get all keys from proc_data_dict
+        # default: get all keys from proc_data_dict
         if key is None:
             try:
                 key = list(self.proc_data_dict.keys())
@@ -837,7 +851,7 @@ class BaseDataAnalysis(object):
             return
 
         # Check weather there is any data to save
-        if hasattr(self, 'proc_data_dict') and self.proc_data_dict is not None\
+        if hasattr(self, 'proc_data_dict') and self.proc_data_dict is not None \
                 and key in self.proc_data_dict:
             fn = self.options_dict.get('analysis_result_file', False)
             if fn == False:
@@ -989,7 +1003,7 @@ class BaseDataAnalysis(object):
                     else:
                         plotfn(pdict=pdict,
                                axs=self.axs[pdict['fig_id']].flatten()[
-                               pdict['ax_id']])
+                                   pdict['ax_id']])
                         self.axs[pdict['fig_id']].flatten()[
                             pdict['ax_id']].figure.subplots_adjust(
                             hspace=0.35)
@@ -1157,7 +1171,7 @@ class BaseDataAnalysis(object):
         if plot_barwidthx is None:
             plot_barwidthx = plot_xvals[1] - plot_xvals[0]
         if not hasattr(plot_barwidthx, '__iter__'):
-            plot_barwidthx = np.ones_like(zpos)*plot_barwidthx
+            plot_barwidthx = np.ones_like(zpos) * plot_barwidthx
         if plot_barwidthy is None:
             plot_barwidthy = plot_yvals[1] - plot_yvals[0]
         if not hasattr(plot_barwidthy, '__iter__'):
@@ -1185,7 +1199,7 @@ class BaseDataAnalysis(object):
                     plot_color = np.repeat(plot_color, n).reshape(-1, n).T
 
         zsort = plot_barkws.pop('zsort', 'max')
-        p_out = pfunc(xpos - plot_barwidthx/2, ypos - plot_barwidthy/2, zpos,
+        p_out = pfunc(xpos - plot_barwidthx / 2, ypos - plot_barwidthy / 2, zpos,
                       plot_barwidthx, plot_barwidthy, plot_barheight,
                       color=plot_color,
                       zsort=zsort, **plot_barkws)
@@ -1685,7 +1699,7 @@ class BaseDataAnalysis(object):
                 plot_cbarwidth = str_to_float(plot_cbarwidth)
                 plot_cbarpad = str_to_float(plot_cbarpad)
                 axs.cax, _ = mpl.colorbar.make_axes(
-                    axs, shrink=1-plot_cbarwidth-plot_cbarpad, pad=plot_cbarpad,
+                    axs, shrink=1 - plot_cbarwidth - plot_cbarpad, pad=plot_cbarpad,
                     orientation=orientation)
                 cmap = pdict.get('colormap')
         else:
@@ -1860,9 +1874,9 @@ class BaseDataAnalysis(object):
         axes_labelcolor = kwargs.get('axes_labelcolor', 'k')
 
         fig_size_dim = 10
-        golden_ratio = (1+np.sqrt(5))/2
+        golden_ratio = (1 + np.sqrt(5)) / 2
         fig_size = kwargs.get('fig_size',
-                              (fig_size_dim, fig_size_dim/golden_ratio))
+                              (fig_size_dim, fig_size_dim / golden_ratio))
         dpi = kwargs.get('dpi', 300)
 
         params = {'figure.figsize': fig_size,
@@ -1895,18 +1909,17 @@ class BaseDataAnalysis(object):
 
     def plot_vlines_auto(self, pdict, axs):
         xs = pdict.get('xdata')
-        for i,x in enumerate(xs):
+        for i, x in enumerate(xs):
             d = {}
             for k in pdict:
                 lk = k[:-1]
-                #if lk in signature(axs.axvline).parameters:
+                # if lk in signature(axs.axvline).parameters:
                 if k not in ['xdata', 'plotfn', 'ax_id', 'do_legend']:
                     try:
                         d[lk] = pdict[k][i]
                     except:
                         pass
             axs.axvline(x=x, **d)
-
 
 
 def plot_scatter_errorbar(self, ax_id, xdata, ydata, xerr=None, yerr=None, pdict=None):
@@ -1985,6 +1998,6 @@ def _merge_dict_rec(dict_a: dict, dict_b: dict):
 
 def str_to_float(s):
     if s[-1] == '%':
-        return float(s.strip('%'))/100
+        return float(s.strip('%')) / 100
     else:
         return float(s)


### PR DESCRIPTION
By @chellings @nathlacroix 
General error handling tested on S17. Latest changes (flexible choice and changes to daemon) only on a virtual setup by @nathlacroix .

This pull request gives the possibility to enable and disable the raising of exceptions in the BaseDataAnalysis.

- Default behavior is to just log the analysis exceptions but in case "raise_exceptions=True" is passed to the base analysis, the exceptions occuring during the analysis will be raised.
- Enable raise_exceptions by default in jobs for the AnalysisDaemon, such that the exceptions are caught by the daemon and the job properly marked as "failed".

In this pull request @nathlacroix  also refactored the base_analysis.py file to suit PEP8 white space standards

FYI @antsr 

