### PR TITLE
Fix hashables() in two new pulse types to include pulse_off setting

### DIFF
--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -201,6 +201,8 @@ class SSB_DRAG_pulse_with_cancellation(SSB_DRAG_pulse):
     def hashables(self, tstart, channel):
         if channel in [self.I_channel, self.Q_channel]:
             return super().hashables(tstart, channel)
+        if self.pulse_off:
+            return ['Offpulse', self.algorithm_time() - tstart, self.length]
         for (i, q), cpars in self.cancellation_params.items():
             if channel != i and channel != q:
                 continue

--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -302,6 +302,8 @@ class GaussianFilteredPiecewiseConstPulse(pulse.Pulse):
     def hashables(self, tstart, channel):
         if channel not in self.channels:
             return []
+        if self.pulse_off:
+            return ['Offpulse', self.algorithm_time() - tstart, self.length]
         hashlist = [type(self), self.algorithm_time() - tstart]
         idx = self.channels.index(channel)
         chan_lens = self.lengths[idx]


### PR DESCRIPTION
Fixes the hashables() functions of GaussianFilteredPiecewiseConstPulse and SSB_DRAG_pulse_with_cancellation.

This has been used on S17 already, but was missing in the quantum experiment pull request.

Easy to review for @antsr :-)