### PR TITLE
CPhase: added num_cz_gates to kw_for_task_keys

### DIFF
--- a/pycqed/measurement/calibration/two_qubit_gates.py
+++ b/pycqed/measurement/calibration/two_qubit_gates.py
@@ -690,7 +690,7 @@ class CPhase(CalibBuilder):
         :param n_cal_points_per_state: see CalibBuilder.get_cal_points()
     ...
     """
-    kw_for_task_keys = ['ref_pi_half']
+    kw_for_task_keys = ['ref_pi_half', 'num_cz_gates']
 
     def __init__(self, task_list, sweep_points=None, **kw):
         try:


### PR DESCRIPTION
After this change, num_cz_gates can also be passed as a keyword argument to CPhase instead of passing it individually for each task.

By @christiankraglundandersen 
From S17

Easy to review for @stephlazar  :-) 