### PR TITLE
More robust plotting code in MultiQubit_SingleShot_Analysis

### DIFF
--- a/pycqed/analysis_v2/readout_analysis.py
+++ b/pycqed/analysis_v2/readout_analysis.py
@@ -1681,10 +1681,10 @@ class MultiQubit_SingleShot_Analysis(ba.BaseDataAnalysis):
 
         plot_dict = {
             'axid': "ptable",
-            'plotfn': self.plot_colorx,
+            'plotfn': self.plot_colorxy,
             'xvals': np.arange(len(self.observables))[obs_filter],
-            'yvals': np.array(len(self.observables)*[ylist]),
-            'zvals': plt_data,
+            'yvals': ylist,
+            'zvals': plt_data.T,
             'xlabel': "Channels",
             'ylabel': "Segments",
             'zlabel': "Counts",


### PR DESCRIPTION
by using colorxy instead of colorx

Has been used for a while on S17. Not sure who did the change there, but seems to be fine.

FYI @stephlazar @antsr 