### PR TITLE
Store flux_distortion in QuDev_transmon and related changes

### DIFF
--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -379,13 +379,8 @@ class QuDev_transmon(Qubit):
                            parameter_class=ManualParameter)
 
         # ac flux parameters
-        DEFAULT_FLUX_DISTORTION = dict(channel='',
-                                       filter_path='',
-                                       IIR_filter_list=[],
-                                       FIR_filter_list=[dict(type='Gaussian',
-                                                             sigma=2e-9,
-                                                             nr_sigma=40,
-                                                             dt=1 / 2.4e9)],
+        DEFAULT_FLUX_DISTORTION = dict(IIR_filter_list=[],
+                                       FIR_filter_list=[],
                                        scale_IIR=1,
                                        distortion='off',
                                        charge_buildup_compensation=True,

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -41,6 +41,16 @@ except ModuleNotFoundError:
     log.warning('"readout_mode_simulations_for_CLEAR_pulse" not imported.')
 
 class QuDev_transmon(Qubit):
+    DEFAULT_FLUX_DISTORTION = dict(
+        IIR_filter_list=[],
+        FIR_filter_list=[],
+        scale_IIR=1,
+        distortion='off',
+        charge_buildup_compensation=True,
+        compensation_pulse_delay=100e-9,
+        compensation_pulse_gaussian_filter_sigma=0,
+    )
+
     def __init__(self, name, **kw):
         super().__init__(name, **kw)
 
@@ -382,17 +392,9 @@ class QuDev_transmon(Qubit):
                            parameter_class=ManualParameter)
 
         # ac flux parameters
-        DEFAULT_FLUX_DISTORTION = dict(
-            IIR_filter_list=[],
-            FIR_filter_list=[],
-            scale_IIR=1,
-            distortion='off',
-            charge_buildup_compensation=True,
-            compensation_pulse_delay=100e-9,
-            compensation_pulse_gaussian_filter_sigma=0,
-        )
         self.add_parameter('flux_distortion', parameter_class=ManualParameter,
-                           initial_value=DEFAULT_FLUX_DISTORTION,
+                           initial_value=deepcopy(
+                               self.DEFAULT_FLUX_DISTORTION),
                            vals=vals.Dict())
 
 
@@ -3835,16 +3837,7 @@ class QuDev_transmon(Qubit):
             pulsar = self.find_instrument('Pulsar')
         if datadir is None:
             datadir = self.find_instrument('MC').datadir()
-        DEFAULT_FLUX_DISTORTION = dict(
-            IIR_filter_list=[],
-            FIR_filter_list=[],
-            scale_IIR=1,
-            distortion='off',
-            charge_buildup_compensation=True,
-            compensation_pulse_delay=100e-9,
-            compensation_pulse_gaussian_filter_sigma=0,
-        )
-        flux_distortion = deepcopy(DEFAULT_FLUX_DISTORTION)
+        flux_distortion = deepcopy(self.DEFAULT_FLUX_DISTORTION)
         flux_distortion.update(self.flux_distortion())
 
         filterCoeffs = {}

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -382,12 +382,15 @@ class QuDev_transmon(Qubit):
                            parameter_class=ManualParameter)
 
         # ac flux parameters
-        DEFAULT_FLUX_DISTORTION = dict(IIR_filter_list=[],
-                                       FIR_filter_list=[],
-                                       scale_IIR=1,
-                                       distortion='off',
-                                       charge_buildup_compensation=True,
-                                       compensation_pulse_delay=100e-9)
+        DEFAULT_FLUX_DISTORTION = dict(
+            IIR_filter_list=[],
+            FIR_filter_list=[],
+            scale_IIR=1,
+            distortion='off',
+            charge_buildup_compensation=True,
+            compensation_pulse_delay=100e-9,
+            compensation_pulse_gaussian_filter_sigma=0,
+        )
         self.add_parameter('flux_distortion', parameter_class=ManualParameter,
                            initial_value=DEFAULT_FLUX_DISTORTION,
                            vals=vals.Dict())
@@ -3811,12 +3814,15 @@ class QuDev_transmon(Qubit):
             pulsar = self.find_instrument('Pulsar')
         if datadir is None:
             datadir = self.find_instrument('MC').datadir()
-        DEFAULT_FLUX_DISTORTION = dict(IIR_filter_list=[],
-                                       FIR_filter_list=[],
-                                       scale_IIR=1,
-                                       distortion='off',
-                                       charge_buildup_compensation=True,
-                                       compensation_pulse_delay=100e-9)
+        DEFAULT_FLUX_DISTORTION = dict(
+            IIR_filter_list=[],
+            FIR_filter_list=[],
+            scale_IIR=1,
+            distortion='off',
+            charge_buildup_compensation=True,
+            compensation_pulse_delay=100e-9,
+            compensation_pulse_gaussian_filter_sigma=0,
+        )
         flux_distortion = deepcopy(DEFAULT_FLUX_DISTORTION)
         flux_distortion.update(self.flux_distortion())
 
@@ -3858,7 +3864,8 @@ class QuDev_transmon(Qubit):
         pulsar.set(f'{self.flux_pulse_channel()}_distortion_dict',
                    filterCoeffs)
         for param in ['distortion', 'charge_buildup_compensation',
-                      'compensation_pulse_delay']:
+                      'compensation_pulse_delay',
+                      'compensation_pulse_gaussian_filter_sigma']:
             pulsar.set(f'{self.flux_pulse_channel()}_{param}',
                        flux_distortion[param])
 

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -3850,7 +3850,7 @@ class QuDev_transmon(Qubit):
         filterCoeffs = {}
         for fclass in 'IIR', 'FIR':
             filterCoeffs[fclass] = []
-            for f in self.flux_distortion()[f'{fclass}_filter_list']:
+            for f in flux_distortion[f'{fclass}_filter_list']:
                 if f['type'] == 'Gaussian':
                     coeffs = fl_predist.gaussian_filter_kernel(
                         f.get('sigma', 1e-9),

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -30,6 +30,9 @@ from pycqed.measurement import mc_parameter_wrapper
 import pycqed.analysis_v2.spectroscopy_analysis as sa
 from pycqed.utilities import math
 import pycqed.analysis.fitting_models as fit_mods
+import os
+import \
+    pycqed.measurement.waveform_control.fluxpulse_predistortion as fl_predist
 
 try:
     import pycqed.simulations.readout_mode_simulations_for_CLEAR_pulse \
@@ -3801,6 +3804,63 @@ class QuDev_transmon(Qubit):
         MC.run_2D('Flux_scope_nzcz_alpha' + self.msmt_suffix)
 
         ma.MeasurementAnalysis(TwoD=True)
+
+    def set_distortion_in_pulsar(self, pulsar=None, datadir=None):
+
+        if pulsar is None:
+            pulsar = self.find_instrument('Pulsar')
+        if datadir is None:
+            datadir = self.find_instrument('MC').datadir()
+        DEFAULT_FLUX_DISTORTION = dict(IIR_filter_list=[],
+                                       FIR_filter_list=[],
+                                       scale_IIR=1,
+                                       distortion='off',
+                                       charge_buildup_compensation=True,
+                                       compensation_pulse_delay=100e-9)
+        flux_distortion = deepcopy(DEFAULT_FLUX_DISTORTION)
+        flux_distortion.update(self.flux_distortion())
+
+        filterCoeffs = {}
+        for fclass in 'IIR', 'FIR':
+            filterCoeffs[fclass] = []
+            for f in self.flux_distortion()[f'{fclass}_filter_list']:
+                if f['type'] == 'Gaussian':
+                    coeffs = fl_predist.gaussian_filter_kernel(
+                        f.get('sigma', 1e-9),
+                        f.get('nr_sigma', 40),
+                        f.get('dt', 1 / 2.4e9))
+                elif f['type'] == 'csv':
+                    filename = os.path.join(datadir,
+                                            f['filename'].lstrip('\\'))
+                    if fclass == 'IIR':
+                        coeffs = fl_predist.import_iir(filename)
+                    else:
+                        coeffs = np.loadtxt(filename)
+                else:
+                    raise KeyError(f"Unknown filter type {f['type']}")
+                filterCoeffs[fclass].append(coeffs)
+
+        if len(filterCoeffs['FIR']) > 0:
+            filterCoeffs['FIR'] = [
+                fl_predist.combine_FIR_filters(filterCoeffs['FIR'])]
+        else:
+            del filterCoeffs['FIR']
+        if len(filterCoeffs['IIR']) > 1:
+            log.warning('For now, only one IIR filter can be used. Taking '
+                        'the last one.')
+        if len(filterCoeffs['IIR']) > 0:
+            filterCoeffs['IIR'] = filterCoeffs['IIR'][-1]
+            fl_predist.scale_and_negate_IIR(filterCoeffs['IIR'],
+                                 flux_distortion['scale_IIR'])
+        else:
+            del filterCoeffs['IIR']
+
+        pulsar.set(f'{self.flux_pulse_channel()}_distortion_dict',
+                   filterCoeffs)
+        for param in ['distortion', 'charge_buildup_compensation',
+                      'compensation_pulse_delay']:
+            pulsar.set(f'{self.flux_pulse_channel()}_{param}',
+                       flux_distortion[param])
 
 
 def add_CZ_pulse(qbc, qbt):

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -3848,7 +3848,8 @@ class QuDev_transmon(Qubit):
                     coeffs = fl_predist.gaussian_filter_kernel(
                         f.get('sigma', 1e-9),
                         f.get('nr_sigma', 40),
-                        f.get('dt', 1 / 2.4e9))
+                        f.get('dt', 1 / pulsar.clock(
+                            channel=self.flux_pulse_channel())))
                 elif f['type'] == 'csv':
                     filename = os.path.join(datadir,
                                             f['filename'].lstrip('\\'))

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -3809,7 +3809,16 @@ class QuDev_transmon(Qubit):
         ma.MeasurementAnalysis(TwoD=True)
 
     def set_distortion_in_pulsar(self, pulsar=None, datadir=None):
+        """
+        Configures the fluxline distortion in a pulsar object according to the
+        settings in the parameter flux_distortion of the qubit object.
 
+        :param pulse: the pulsar object. If None, self.find_instrument is
+            used to find an obejct called 'Pulsar'.
+        :param datadir: path to the pydata directory. If None,
+            self.find_instrument is used to find an obejct called 'MC' and
+            the datadir of MC is used.
+        """
         if pulsar is None:
             pulsar = self.find_instrument('Pulsar')
         if datadir is None:

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -378,6 +378,23 @@ class QuDev_transmon(Qubit):
                            label='QCoDeS parameter to sweep the dc flux',
                            parameter_class=ManualParameter)
 
+        # ac flux parameters
+        DEFAULT_FLUX_DISTORTION = dict(channel='',
+                                       filter_path='',
+                                       IIR_filter_list=[],
+                                       FIR_filter_list=[dict(type='Gaussian',
+                                                             sigma=2e-9,
+                                                             nr_sigma=40,
+                                                             dt=1 / 2.4e9)],
+                                       scale_IIR=1,
+                                       distortion='off',
+                                       charge_buildup_compensation=True,
+                                       compensation_pulse_delay=100e-9)
+        self.add_parameter('flux_distortion', parameter_class=ManualParameter,
+                           initial_value=DEFAULT_FLUX_DISTORTION,
+                           vals=vals.Dict())
+
+
         # Pulse preparation parameters
         DEFAULT_PREP_PARAMS = dict(preparation_type='wait',
                                    post_ro_wait=1e-6, reset_reps=1,

--- a/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
+++ b/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
@@ -92,8 +92,17 @@ def gaussian_filter_kernel(sigma,nr_sigma,dt):
     return np.array(gauss_kernel)
 
 
+def scale_and_negate_IIR(filter_coeffs, scale):
+    for i in range(len(filter_coeffs[0])):
+        filter_coeffs[0][i][1] *= -1
+    filter_coeffs[1][0] /= scale
 
 
-
-
-
+def combine_FIR_filters(kernels):
+    if hasattr(kernels[0], '__iter__'):
+        kernel_combined = kernels[0]
+        for kernel in kernels[1:]:
+            kernel_combined = np.convolve(kernel, kernel_combined)
+        return kernel_combined
+    else:
+        return kernels

--- a/pycqed/measurement/waveform_control/pulsar.py
+++ b/pycqed/measurement/waveform_control/pulsar.py
@@ -169,6 +169,9 @@ class UHFQCPulsar:
         self.add_parameter('{}_compensation_pulse_delay'.format(name), 
                            initial_value=0, unit='s',
                            parameter_class=ManualParameter)
+        self.add_parameter('{}_compensation_pulse_gaussian_filter_sigma'.format(name),
+                           initial_value=0, unit='s',
+                           parameter_class=ManualParameter)
 
     @staticmethod
     def _uhfqc_setter(obj, id, par):
@@ -448,6 +451,9 @@ class HDAWG8Pulsar:
                             parameter_class=ManualParameter,
                             vals=vals.Numbers(0., 1.), initial_value=0.5)
         self.add_parameter('{}_compensation_pulse_delay'.format(name), 
+                           initial_value=0, unit='s',
+                           parameter_class=ManualParameter)
+        self.add_parameter('{}_compensation_pulse_gaussian_filter_sigma'.format(name),
                            initial_value=0, unit='s',
                            parameter_class=ManualParameter)
         self.add_parameter('{}_internal_modulation'.format(name), 
@@ -784,6 +790,9 @@ class AWG5014Pulsar:
                             parameter_class=ManualParameter,
                             vals=vals.Numbers(0., 1.), initial_value=0.5)
         self.add_parameter('{}_compensation_pulse_delay'.format(name), 
+                           initial_value=0, unit='s',
+                           parameter_class=ManualParameter)
+        self.add_parameter('{}_compensation_pulse_gaussian_filter_sigma'.format(name),
                            initial_value=0, unit='s',
                            parameter_class=ManualParameter)
     

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -408,7 +408,9 @@ class Segment:
                 'amplitude': amp,
                 'buffer_length_start': comp_delay,
                 'buffer_length_end': comp_delay,
-                'pulse_length': length
+                'pulse_length': length,
+                'gaussian_filter_sigma': self.pulsar.get(
+                    '{}_compensation_pulse_gaussian_filter_sigma'.format(c))
             }
             pulse = pl.BufferedSquarePulse(
                 last_element, c, name='compensation_pulse_{}'.format(i), **kw)


### PR DESCRIPTION
This pull request:
- adds the possibility to store a fluxline filter configuration in the parameter flux_distortion of a QuDev_transmon
- adds the method set_distortion_in_pulsar to QuDev_transmon, which configures pulsar according to the settings in the parameter flux_distortion
- adds helper functions to the fluxpulse_predistortion module, which are required for set_distortion_in_pulsar
- adds the possibility to specify a compensation_pulse_gaussian_filter_sigma for smooth compensation pulses (can be used to avoid clipping errors in cases where one decides to accept an overshoot that is smoothed out only by the Gaussian filter of pulses)

Tested on S17

FYI @stephlazar 