### PR TITLE
Bugfixes in Flux Pulse Scope Measurement and Analysis

### DIFF
--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -7087,8 +7087,14 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
         if self.ghost is None:
             self.ghost = {qbn: False for qbn in self.qb_names}
 
-    def prepare_fitting_slice(self, freqs, qbn, slice_idx, mu_guess):
-        data_slice = self.proc_data_dict['proc_data_to_fit'][qbn][:, slice_idx]
+    def prepare_fitting_slice(self, freqs, qbn, mu_guess,
+                              slice_idx=None, data_slice=None):
+        if slice_idx is None:
+            raise ValueError('"since_idx" cannot both be None. It is used '
+                             'for unique names in the fit_dicts.')
+        if data_slice is None:
+            data_slice = self.proc_data_dict['proc_data_to_fit'][qbn][
+                         :, slice_idx]
         GaussianModel = fit_mods.GaussianModel
         ampl_guess = (data_slice.max() - data_slice.min()) / \
                      0.4 * self.sign_of_peaks[qbn] * self.sigma_guess[qbn]
@@ -7120,12 +7126,13 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
         for qbn in self.qb_names:
             param_name = self.mospm[qbn][1]
             data = self.proc_data_dict['proc_data_to_fit'][qbn]
-            freqs = self.proc_data_dict['proc_sweep_points_2D_dict'][qbn][
-                param_name]
             delays = self.proc_data_dict['proc_sweep_points_dict'][qbn][
                 'sweep_points']
+            self.freqs_for_fit[qbn] = len(delays) * ['']
             for i, delay in enumerate(delays):
                 data_slice = data[:, i]
+                freqs = self.proc_data_dict['proc_sweep_points_2D_dict'][qbn][
+                    param_name]
                 if self.rectangles_exclude is not None and \
                         self.rectangles_exclude.get(qbn, None) is not None:
                     for rectangle in self.rectangles_exclude[qbn]:
@@ -7135,10 +7142,11 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                                                freqs < rectangle[3]))
                             freqs = freqs[reduction_arr]
                             data_slice = data_slice[reduction_arr]
-                self.freqs_for_fit[qbn] = freqs
+                self.freqs_for_fit[qbn][i] = freqs
                 mu_guess = freqs[np.argmax(
                     data_slice * self.sign_of_peaks[qbn])]
-                self.prepare_fitting_slice(freqs, qbn, i, mu_guess)
+                self.prepare_fitting_slice(freqs, qbn, mu_guess, i,
+                                           data_slice=data_slice)
 
     def analyze_fit_results(self):
         self.proc_data_dict['analysis_params_dict'] = OrderedDict()
@@ -7147,9 +7155,8 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                 'sweep_points']
             fitted_freqs = np.zeros(len(delays))
             fitted_freqs_errs = np.zeros(len(delays))
-
             fit_keys = [k for k in self.fit_dicts if qbn in k]
-            assert len(fit_keys) == len(fitted_freqs)
+            assert len(fitted_freqs) == len(fit_keys)
             deep = False
             for i, fk in enumerate(fit_keys):
                 fit_res = self.fit_dicts[fk]['fit_res']
@@ -7169,7 +7176,7 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                             if deep:
                                 mu_guess = fitted_freqs[i-1]
                                 self.prepare_fitting_slice(
-                                    self.freqs_for_fit[qbn], qbn, i, mu_guess)
+                                    self.freqs_for_fit[qbn][i], qbn, mu_guess, i)
                                 self.run_fitting(keys_to_fit=[fk])
                                 fitted_freqs[i] = self.fit_dicts[fk][
                                     'fit_res'].best_values['mu']
@@ -7187,7 +7194,7 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                             if deep:
                                 mu_guess = fitted_freqs[i - 1]
                                 self.prepare_fitting_slice(
-                                    self.freqs_for_fit[qbn], qbn, i, mu_guess)
+                                    self.freqs_for_fit[qbn][i], qbn, mu_guess, i)
                                 self.run_fitting(keys_to_fit=[fk])
                                 fitted_freqs[i] = self.fit_dicts[fk][
                                     'fit_res'].best_values['mu']

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -3438,7 +3438,8 @@ class QuDev_transmon(Qubit):
             name='Drive frequency',
             parameter_name='Drive frequency', unit='Hz'))
         MC.set_sweep_points_2D(sweep_points_2D)
-        MC.set_detector_function(self.int_avg_det)
+        det_func = self.int_avg_det
+        MC.set_detector_function(det_func)
         sweep_points = SweepPoints('delay', delays, unit='s',
                                    label=r'delay, $\tau$', dimension=0)
         sweep_points.add_sweep_parameter('freq', freqs, unit='Hz',
@@ -3451,6 +3452,8 @@ class QuDev_transmon(Qubit):
                              'sweep_points_dict_2D': {self.name: freqs},
                              'sweep_points': sweep_points,
                              'meas_obj_sweep_points_map': mospm,
+                             'meas_obj_value_names_map':
+                                 {self.name: det_func.value_names},
                              'use_cal_points': cal_points,
                              'preparation_params': prep_params,
                              'cal_points': repr(cp),

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -3439,10 +3439,18 @@ class QuDev_transmon(Qubit):
             parameter_name='Drive frequency', unit='Hz'))
         MC.set_sweep_points_2D(sweep_points_2D)
         MC.set_detector_function(self.int_avg_det)
+        sweep_points = SweepPoints('delay', delays, unit='s',
+                                   label=r'delay, $\tau$', dimension=0)
+        sweep_points.add_sweep_parameter('freq', freqs, unit='Hz',
+                                         label=r'drive frequency, $f_d$',
+                                         dimension=1)
+        mospm = {self.name: ['delay', 'freq']}
         if exp_metadata is None:
             exp_metadata = {}
         exp_metadata.update({'sweep_points_dict': {self.name: delays},
                              'sweep_points_dict_2D': {self.name: freqs},
+                             'sweep_points': sweep_points,
+                             'meas_obj_sweep_points_map': mospm,
                              'use_cal_points': cal_points,
                              'preparation_params': prep_params,
                              'cal_points': repr(cp),
@@ -3454,8 +3462,9 @@ class QuDev_transmon(Qubit):
 
         if analyze:
             try:
-                tda.MultiQubit_TimeDomain_Analysis(qb_names=[self.name],
-                                                   options_dict=dict(TwoD=True))
+                tda.FluxPulseScopeAnalysis(
+                    qb_names=[self.name],
+                    options_dict=dict(TwoD=True, global_PCA=True,))
             except Exception:
                 ma.MeasurementAnalysis(TwoD=True)
 

--- a/pycqed/measurement/pulse_sequences/fluxing_sequences.py
+++ b/pycqed/measurement/pulse_sequences/fluxing_sequences.py
@@ -428,7 +428,8 @@ def fluxpulse_scope_sequence(
     flux_pulse['name'] = 'FPS_Flux'
     flux_pulse['ref_pulse'] = 'FPS_Pi'
     flux_pulse['ref_point'] = 'middle'
-    flux_pulse_delays = -delays - flux_pulse.get('buffer_length_start', 0)
+    flux_pulse_delays = -np.asarray(delays) - flux_pulse.get(
+        'buffer_length_start', 0)
 
     ro_pulse = deepcopy(operation_dict['RO ' + qb_name])
     ro_pulse['name'] = 'FPS_Ro'


### PR DESCRIPTION
- add sweep_points and related info to metadata in measure_flux_pulse_scope (required by new analysis class)
- call new analysis class (v2) in measure_flux_pulse_scope
- fluxpulse_scope_sequence: do not crash if delays is a list (instead of an np.array)
- FluxPulseScopeAnalysis V2: Fixes bugs when rectangles_exclude are provided 

FYI @antsr 