### PR TITLE
Bugfix in Detector_Function.generate_metadata()

### DIFF
--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -58,7 +58,8 @@ class Detector_Function(object):
         # uhfName_detectorName
         detectors_dict = {}
         for d in det_metadata.pop('detectors', []):
-            detectors_dict.update({f'{d["UHFs"][0]} {d["name"]}': d})
+            if isinstance(d, dict):
+                detectors_dict.update({f'{d["UHFs"][0]} {d["name"]}': d})
         if len(detectors_dict):
             det_metadata['detectors'] = detectors_dict
 

--- a/pycqed/measurement/measurement_control.py
+++ b/pycqed/measurement/measurement_control.py
@@ -212,12 +212,12 @@ class MeasurementControl(Instrument):
                       datadir=self.datadir()) as self.data_object:
             if exp_metadata is not None:
                 self.exp_metadata = deepcopy(exp_metadata)
-                metadata = self.detector_function.generate_metadata()
-                metadata.update(exp_metadata)
-                self.save_exp_metadata(metadata, self.data_object)
             else:
                 # delete metadata from previous measurement
                 self.exp_metadata = {}
+            det_metadata = self.detector_function.generate_metadata()
+            self.exp_metadata.update(det_metadata)
+            self.save_exp_metadata(self.exp_metadata, self.data_object)
             try:
                 self.check_keyboard_interrupt()
                 self.get_measurement_begintime()


### PR DESCRIPTION
Found a small bug in generating the detector functions metadata which caused it to fail whenever UHFQC_multi_detector wasn't used.
