### PR TITLE
bugfix DynamicPhase: fixed handling of child measurements (autorun, measure, analyze, update, repr)

### DIFF
--- a/pycqed/measurement/calibration/two_qubit_gates.py
+++ b/pycqed/measurement/calibration/two_qubit_gates.py
@@ -549,10 +549,16 @@ class CalibBuilder(MultiTaskingExperiment):
     """
     def __init__(self, task_list, **kw):
         super().__init__(task_list=task_list, **kw)
-        self.update = kw.pop('update', False)
+        self.init_update_callback(**kw)
 
-        # if no callback was provided by the user, set the template function
-        # run_update() as callback conditioned on self.update flag
+    def init_update_callback(self, update=False, **kw):
+        """
+        Configures QuantumExperiement to run the function run_update()
+        (or a user-specified callback function) in autorun after measurement
+        and analysis, conditioned on the flag self.update. The flag is
+        intialized to True if update=True was passed, and False otherwise.
+        """
+        self.update = update
         self.callback = kw.get('callback', self.run_update)
         self.callback_condition = lambda : self.update
 
@@ -965,7 +971,6 @@ class DynamicPhase(CalibBuilder):
 
             self.dynamic_phase_analysis = {}
             self.dyn_phases = {}
-            self.old_dyn_phases = {}
             for task in task_list:
                 if task.get('qubits_to_measure', None) is None:
                     task['qubits_to_measure'] = task['op_code'].split(' ')[1:]
@@ -983,6 +988,7 @@ class DynamicPhase(CalibBuilder):
             qbm_all = [task['qubits_to_measure'] for task in task_list]
             if not self.simultaneous and max([len(qbs) for qbs in qbm_all]) > 1:
                 # create a child for each measurement
+                self.parent = None
                 task_lists = []
                 if self.simultaneous_groups is not None:
                     for group in self.simultaneous_groups:
@@ -1010,23 +1016,29 @@ class DynamicPhase(CalibBuilder):
                                 new_task_list.append(new_task)
                         task_lists.append(new_task_list)
 
-                # device object will be needed for update
+                # We call the init of super() only for the spawned child
+                # measurements. We need special treatment of some properties
+                # in the following lines.
+                # extract device object, which will be needed for update
                 self.dev = kw.get('dev', None)
-                # children should not update
-                self.update = kw.pop('update', False)
-                self.measurements = [DynamicPhase(tl, sweep_points, **kw)
+                # Configure the update callback for the parent. It will be
+                # called after all children have analyzed.
+                self.init_update_callback(**kw)
+                # pop to ensure that children do not update
+                kw.pop('update', None)
+                # spawn the child measurements
+                self.measurements = [DynamicPhase(tl, sweep_points,
+                                                  parent=self, **kw)
                                      for tl in task_lists]
-
-                if self.measurements[0].analyze:
-                    for m in self.measurements:
-                        for k, v in m.dyn_phases.items():
-                            if k not in self.dyn_phases:
-                                self.dyn_phases[k] = {}
-                            self.dyn_phases[k].update(v)
+                # Use the choices for measure and analyze that were extracted
+                # from kw by the children.
+                self.measure = self.measurements[0].measure
+                self.analyze = self.measurements[0].analyze
             else:
                 # this happens if we are in child or if simultaneous=True or
                 # if only one qubit per task is measured
                 self.measurements = [self]
+                self.parent = kw.pop('parent', None)
                 super().__init__(task_list, sweep_points=sweep_points, **kw)
 
                 if self.reset_phases_before_measurement:
@@ -1042,11 +1054,19 @@ class DynamicPhase(CalibBuilder):
                 self.sequences, self.mc_points = self.parallel_sweep(
                     self.preprocessed_task_list, self.dynamic_phase_block,
                     block_align=['center', 'end', 'center', 'start'], **kw)
-                # run measurement & analysis if requested in kw
+            # run measurement & analysis & update if requested in kw
+            # (unless the parent takes care of it)
+            if self.parent is None:
                 self.autorun(**kw)
         except Exception as x:
             self.exception = x
             traceback.print_exc()
+
+    def __repr__(self):
+        if self.measurements[0] != self:  # we have spawned child measurements
+            return 'DynamicPhase: ' + repr(self.measurements)
+        else:
+            return super().__repr__()
 
     def add_default_sweep_points(self, **kw):
         """
@@ -1150,6 +1170,17 @@ class DynamicPhase(CalibBuilder):
         qbs = self.get_qubits(task['qubits_to_measure'])
         return qbs[0] if qbs[0] is not None else qbs[1]
 
+    def run_measurement(self, **kw):
+        """
+        Overloads the method from QuantumExperiment to deal with child
+        measurements.
+        """
+        if self.measurements[0] != self:  # we have spawned child measurements
+            for m in self.measurements:
+                m.run_measurement(**kw)
+        else:
+            super().run_measurement(**kw)
+
     def run_analysis(self, **kw):
         """
         Runs analysis, stores analysis instance in self.dynamic_phase_analysis
@@ -1158,9 +1189,15 @@ class DynamicPhase(CalibBuilder):
              extract_only: (bool) if True, do not plot, default: False
         :return: the dynamic phases dict and the analysis instance
         """
+        if self.measurements[0] != self:  # we have spawned child measurements
+            for m in self.measurements:
+                m.run_analysis(**kw)
+            return  # the rest of the function is executed in the children
+
         qb_names = [l1 for l2 in [task['qubits_to_measure'] for task in
                                   self.task_list] for l1 in l2]
-        self.dynamic_phase_analysis = tda.DynamicPhaseAnalysis(qb_names=qb_names)
+        self.dynamic_phase_analysis = tda.DynamicPhaseAnalysis(
+            qb_names=qb_names, t_start=self.timestamp)
 
         for task in self.task_list:
             if len(task['op_code'].split(' ')) == 3:
@@ -1173,16 +1210,23 @@ class DynamicPhase(CalibBuilder):
                     (self.dynamic_phase_analysis.proc_data_dict[
                         'analysis_params_dict'][f"dynamic_phase_{qb_name}"][
                         'val'] * 180 / np.pi)[0]
-
+        if self.parent is not None:
+            for k, v in self.dyn_phases.items():
+                if k not in self.parent.dyn_phases:
+                    self.parent.dyn_phases[k] = {}
+                self.parent.dyn_phases[k].update(v)
         return self.dyn_phases, self.dynamic_phase_analysis
 
     def run_update(self, **kw):
         assert self.measurements[0].dev is not None, \
             "Update only works with device object provided."
-        assert self.measurements[0].analyze, \
-            "Update is only allowed with analyze=True."
+        assert len(self.dyn_phases) > 0, \
+            "Update is only allowed after running the analysis."
         assert len(self.measurements[0].mc_points[1]) == 1, \
             "Update is only allowed without a soft sweep."
+        assert self.parent is None, \
+            "Update has to be run for the parent object, not for the " \
+            "individual child measurements."
 
         for op, dp in self.dyn_phases.items():
             op_split = op.split(' ')

--- a/pycqed/measurement/calibration/two_qubit_gates.py
+++ b/pycqed/measurement/calibration/two_qubit_gates.py
@@ -557,6 +557,12 @@ class CalibBuilder(MultiTaskingExperiment):
         (or a user-specified callback function) in autorun after measurement
         and analysis, conditioned on the flag self.update. The flag is
         intialized to True if update=True was passed, and False otherwise.
+
+        This helper function is kept separate from the __init__() to allow
+        initializing the update callback without calling the super().__init__.
+        This is needed for the implementation of parent/child measurements in
+        DynamicPhase, where the parent is a CalibBuilder, but never calls
+        the init of CalibBuilder.
         """
         self.update = update
         self.callback = kw.get('callback', self.run_update)

--- a/pycqed/measurement/calibration/two_qubit_gates.py
+++ b/pycqed/measurement/calibration/two_qubit_gates.py
@@ -549,20 +549,15 @@ class CalibBuilder(MultiTaskingExperiment):
     """
     def __init__(self, task_list, **kw):
         super().__init__(task_list=task_list, **kw)
-        self.init_update_callback(**kw)
+        self.set_update_callback(**kw)
 
-    def init_update_callback(self, update=False, **kw):
+    def set_update_callback(self, update=False, **kw):
         """
         Configures QuantumExperiement to run the function run_update()
         (or a user-specified callback function) in autorun after measurement
         and analysis, conditioned on the flag self.update. The flag is
         intialized to True if update=True was passed, and False otherwise.
 
-        This helper function is kept separate from the __init__() to allow
-        initializing the update callback without calling the super().__init__.
-        This is needed for the implementation of parent/child measurements in
-        DynamicPhase, where the parent is a CalibBuilder, but never calls
-        the init of CalibBuilder.
         """
         self.update = update
         self.callback = kw.get('callback', self.run_update)
@@ -1029,7 +1024,7 @@ class DynamicPhase(CalibBuilder):
                 self.dev = kw.get('dev', None)
                 # Configure the update callback for the parent. It will be
                 # called after all children have analyzed.
-                self.init_update_callback(**kw)
+                self.set_update_callback(**kw)
                 # pop to ensure that children do not update
                 kw.pop('update', None)
                 # spawn the child measurements


### PR DESCRIPTION
Please note: PR for merging into Proj/S17

While working on fixing the issue that the new run_update framework did not work properly in DynamicPhase, I realized that there were some further bugs in the handling of child measurements in DynamicPhase. This pull request should fix the behavior of autorun, run_measurement, run_analysis, run_update, and __repr__ to work properly in all cases (inside a child mesasurement, inside a parent, and in the case where no child measurements are needed). Tested on a virtual setup.

After merging this into Proj/S17, I can create a PR to merge the changes from #146 and from this new PR into the master.

FYI @stephlazar 