### PR TITLE
Remove SweepPoints.cast_init and ensure type is unchanged by slicing

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -583,7 +583,7 @@ class BaseDataAnalysis(object):
             self.raw_data_dict = self.add_measured_data(
                 self.raw_data_dict,
                 self.get_param_value('compression_factor', 1),
-                SweepPoints.cast_init(self.get_param_value('sweep_points')),
+                SweepPoints(self.get_param_value('sweep_points')),
                 cp, self.get_param_value('preparation_params',
                                          default_value=dict()))
         else:

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -485,7 +485,7 @@ class BaseDataAnalysis(object):
                 raw_data_dict['soft_sweep_points'] = ssp
             elif sweep_points is not None:
                 # deal with hybrid measurements
-                sp = SweepPoints(from_dict_list=sweep_points)
+                sp = SweepPoints(sweep_points)
                 if mc_points.shape[0] == 1 and len(sp) > 1:
                     hybrid_measurement = True
                     if prep_params is None:

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -253,7 +253,7 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
     def get_sweep_points(self):
         self.sp = self.get_param_value('sweep_points')
         if self.sp is not None:
-            self.sp = SweepPoints.cast_init(self.sp)
+            self.sp = SweepPoints(self.sp)
 
     def create_sweep_points_dict(self):
         sweep_points_dict = self.get_param_value('sweep_points_dict')

--- a/pycqed/analysis_v3/helper_functions.py
+++ b/pycqed/analysis_v3/helper_functions.py
@@ -519,7 +519,7 @@ def get_measurement_properties(data_dict, props_to_extract='all',
         elif 'sp' == prop:
             sp = get_param('sweep_points', data_dict, raise_error=raise_error,
                            **params)
-            props_to_return += [sp_mod.SweepPoints.cast_init(sp)]
+            props_to_return += [sp_mod.SweepPoints(sp)]
         elif 'mospm' == prop:
             meas_obj_sweep_points_map = get_param(
                 'meas_obj_sweep_points_map', data_dict, raise_error=raise_error,
@@ -991,7 +991,7 @@ def read_from_hdf(data_dict, hdf_group):
             if hdf_group.attrs['list_type'] == 'generic_tuple':
                 data_list = tuple(data_list)
             if path[-1] == 'sweep_points':
-                data_list = sp_mod.SweepPoints.cast_init(data_list)
+                data_list = sp_mod.SweepPoints(data_list)
             add_param('.'.join(path), data_list, data_dict, replace_value=True)
         else:
             raise NotImplementedError('cannot read "list_type":"{}"'.format(

--- a/pycqed/analysis_v3/randomized_benchmarking_analysis.py
+++ b/pycqed/analysis_v3/randomized_benchmarking_analysis.py
@@ -62,7 +62,7 @@ def pipeline_single_qubit_rb_ssro(meas_obj_names, mospm, sweep_points,
         sweep_type = {'cliffords': 0, 'seeds': 1}
     slow_cliffords = sweep_type['cliffords'] == 1
 
-    sweep_points = sp_mod.SweepPoints.cast_init(sweep_points)
+    sweep_points = sp_mod.SweepPoints(sweep_points)
     if cal_points is None:
         num_cal_states = 0
     else:
@@ -192,7 +192,7 @@ def pipeline_interleaved_rb_irb_classif(meas_obj_names, mospm, sweep_points,
         sweep_type = {'cliffords': 0, 'seeds': 1}
     slow_cliffords = sweep_type['cliffords'] == 1
 
-    sweep_points = sp_mod.SweepPoints.cast_init(sweep_points)
+    sweep_points = sp_mod.SweepPoints(sweep_points)
     if cal_points is None:
         num_cal_states = 0
     else:
@@ -322,7 +322,7 @@ def pipeline_ssro_measurement(meas_obj_names, mospm, sweep_points, n_shots,
         sweep_type = {'cliffords': 0, 'seeds': 1}
     slow_cliffords = sweep_type['cliffords'] == 1
 
-    sweep_points = sp_mod.SweepPoints.cast_init(sweep_points)
+    sweep_points = sp_mod.SweepPoints(sweep_points)
     if cal_points is None:
         num_cal_states = 0
     else:
@@ -505,7 +505,7 @@ def combine_datafiles_split_by_seeds(data_dict, keys_in, keys_out,
                                       raise_error=True, **params)
     sp_list = [hlp_mod.get_param('sweep_points', mdl, raise_error=True)
                for mdl in metadata_list]
-    sp0 = sp_mod.SweepPoints.cast_init(sp_list[0])
+    sp0 = sp_mod.SweepPoints(sp_list[0])
 
     nr_segments = sp0.length(0) + len(cp.states)
     nr_uploads = sp0.length(1)
@@ -535,7 +535,7 @@ def combine_datafiles_split_by_seeds(data_dict, keys_in, keys_out,
                         in range(len(sp0.get_sweep_dimension(0)))]
 
     for i, sp in enumerate(sp_list):
-        sp = sp_mod.SweepPoints.cast_init(sp)
+        sp = sp_mod.SweepPoints(sp)
         sp_vals_list = sp.get_sweep_params_property('values', 0, 'all')
         for j, sp_vals in enumerate(sp_vals_list):
             sp_all_vals_list[j][i::nr_exp] = sp_vals

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -69,8 +69,7 @@ class T1FrequencySweep(CalibBuilder):
             self.analysis = None
             self.data_to_fit = {qb: 'pe' for qb in self.meas_obj_names}
             self.sweep_points = SweepPoints(
-                from_dict_list=[{}, {}] if self.sweep_points is None
-                else self.sweep_points)
+                [{}, {}] if self.sweep_points is None else self.sweep_points)
             self.add_amplitude_sweep_points()
 
             self.preprocessed_task_list = self.preprocess_task_list(**kw)
@@ -106,7 +105,7 @@ class T1FrequencySweep(CalibBuilder):
         # TODO: check combination of sweep points in task and in sweep_points
         for task in task_list:
             sweep_points = task.get('sweep_points', [{}, {}])
-            sweep_points = SweepPoints(from_dict_list=sweep_points)
+            sweep_points = SweepPoints(sweep_points)
             if len(sweep_points) == 1:
                 sweep_points.add_sweep_dimension()
             if 'qubit_freqs' in sweep_points[1]:

--- a/pycqed/measurement/calibration/two_qubit_gates.py
+++ b/pycqed/measurement/calibration/two_qubit_gates.py
@@ -191,7 +191,7 @@ class MultiTaskingExperiment(QuantumExperiment):
         # Store a copy of the sweep_points (after ensuring that they are a
         # SweepPoints object). This copy will then be extended with prefixed
         # task-specific sweep_points.
-        self.sweep_points = SweepPoints(from_dict_list=given_sweep_points)
+        self.sweep_points = SweepPoints(given_sweep_points)
         # Internally, 1D and 2D sweeps are handled as 2D sweeps.
         while len(self.sweep_points) < 2:
             self.sweep_points.add_sweep_dimension()
@@ -250,14 +250,13 @@ class MultiTaskingExperiment(QuantumExperiment):
                 task[param] = kw.get(param, None)
 
         # Start with sweep points valid for all tasks
-        current_sweep_points = SweepPoints(from_dict_list=sweep_points)
+        current_sweep_points = SweepPoints(sweep_points)
         # generate kw sweep points for the task
         self.generate_kw_sweep_points(task)
         # Add all task sweep points to the current_sweep_points object.
         # If a task-specific sweep point has the same name as a sweep point
         # valid for all tasks, the task-specific one is used for this task.
-        current_sweep_points.update(
-            SweepPoints(from_dict_list=task['sweep_points']))
+        current_sweep_points.update(SweepPoints(task['sweep_points']))
         # Create a list of lists containing for each dimension the names of
         # the task-specific sweep points. These sweep points have to be
         # prefixed with the task prefix later on (in the global sweep
@@ -506,8 +505,7 @@ class MultiTaskingExperiment(QuantumExperiment):
         :param task: a task dictionary ot the kw dictionary
         """
         # make sure that sweep_points is a SweepPoints object
-        task['sweep_points'] = SweepPoints(
-            from_dict_list=task.get('sweep_points', None))
+        task['sweep_points'] = SweepPoints(task.get('sweep_points', None))
         for k, sp_dict_list in self.kw_for_sweep_points.items():
             if isinstance(sp_dict_list, dict):
                 sp_dict_list = [sp_dict_list]
@@ -581,7 +579,7 @@ class CalibBuilder(MultiTaskingExperiment):
         # Clean up sweep points
         sweep_points = deepcopy(sweep_points)
         if sweep_points is None:
-            sweep_points = SweepPoints(from_dict_list=[{}, {}])
+            sweep_points = SweepPoints([{}, {}])
         while len(sweep_points) < 2:
             sweep_points.add_sweep_dimension()
         for i in range(len(sweep_points)):
@@ -651,7 +649,7 @@ class CalibBuilder(MultiTaskingExperiment):
             raise ValueError('"repeat" and "tile" cannot both be > 0.')
         # ensure that sweep_points is a SweepPoints object with at least two
         # dimensions
-        sweep_points = SweepPoints(from_dict_list=sweep_points, min_length=2)
+        sweep_points = SweepPoints(sweep_points, min_length=2)
         # If there already exist sweep points in dimension 0, this adapt the
         # number of phases to the number of existing sweep points.
         if len(sweep_points[0]) > 0:

--- a/pycqed/measurement/measurement_control.py
+++ b/pycqed/measurement/measurement_control.py
@@ -651,7 +651,7 @@ class MeasurementControl(Instrument):
         sp = self.exp_metadata.get('sweep_points', None)
         if sp is not None:
             try:
-                sp = sp_mod.SweepPoints.cast_init(sp)
+                sp = sp_mod.SweepPoints(sp)
             except Exception:
                 sp = None
         # create a reverse lookup dictionary (value names measure object map)

--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -2635,8 +2635,7 @@ def measure_chevron(dev, qbc, qbt, hard_sweep_params, soft_sweep_params,
     MC.set_sweep_points_2D(soft_sweep_points)
     det_func = qbr.int_avg_classif_det if classified else qbr.int_avg_det
     MC.set_detector_function(det_func)
-    sweep_points = SweepPoints(from_dict_list=[hard_sweep_params,
-                                               soft_sweep_params])
+    sweep_points = SweepPoints([hard_sweep_params, soft_sweep_params])
     exp_metadata.update({
         'preparation_params': prep_params,
         'cal_points': repr(cp),

--- a/pycqed/measurement/sweep_points.py
+++ b/pycqed/measurement/sweep_points.py
@@ -46,6 +46,20 @@ class SweepPoints(list):
     """
     def __init__(self, param=None, values=None, unit='', label=None,
                  dimension=-1, min_length=0):
+        """
+        Create a SweepPoints instance.
+        :param param: list of dicts, repr of SweepPoints instance, or name of
+            a sweep parameter
+        :param values: list or array of numeric values of the sweep parameter
+            specified by param
+        :param unit: string specifying the unit of the sweep parameter
+            specified by param
+        :param label: str specifying the (latex style) label/name of the sweep
+            parameter specified by param
+        :param dimension: sweep dimension where sweep parameter param should be
+            added
+        :param min_length: minimum number of sweep dimensions to create
+        """
         super().__init__()
         if isinstance(param, list):
             self.add_dict_list(param)
@@ -61,12 +75,21 @@ class SweepPoints(list):
             self.add_sweep_dimension()
 
     def __getitem__(self, i):
+        """
+        Overloading of List.__getitem__ to ensure type SweepPoints is preserved.
+        :param i: element or slice
+        :return: element or new SweepPoints instance
+        """
         new_data = super().__getitem__(i)
         if type(i) == slice:
             new_data = self.__class__(new_data)
         return new_data
 
     def add_dict_list(self, dict_list):
+        """
+        Append the dicts in dict_list to self.
+        :param dict_list: list of dictionaries in the format of this class
+        """
         for d in deepcopy(dict_list):
             if len(d) == 0 or isinstance(list(d.values())[0], tuple):
                 # assume that dicts have the same format as this class

--- a/pycqed/measurement/sweep_points.py
+++ b/pycqed/measurement/sweep_points.py
@@ -64,6 +64,12 @@ class SweepPoints(list):
         while len(self) < min_length:
             self.add_sweep_dimension()
 
+    def __getitem__(self, i):
+        new_data = super().__getitem__(i)
+        if type(i) == slice:
+            new_data = self.cast_init(new_data)
+        return new_data
+
     def add_sweep_parameter(self, param_name, values, unit='', label=None,
                             dimension=-1):
         """

--- a/pycqed/measurement/sweep_points.py
+++ b/pycqed/measurement/sweep_points.py
@@ -44,31 +44,39 @@ class SweepPoints(list):
         sp.add_sweep_parameter(f'amps_{qb}', np.linspace(0, 1, 20),
         'V', 'Pulse amplitude, $A$')
     """
-    def __init__(self, param_name=None, values=None, unit='', label=None,
-                 dimension=-1, from_dict_list=None, min_length=0):
+    def __init__(self, param=None, values=None, unit='', label=None,
+                 dimension=-1, min_length=0):
         super().__init__()
-        if param_name is not None and values is not None:
-            self.add_sweep_parameter(param_name, values, unit, label,
-                                     dimension)
-        elif from_dict_list is not None:
-            for d in deepcopy(from_dict_list):
-                if len(d) == 0 or isinstance(list(d.values())[0], tuple):
-                    # assume that dicts have the same format as this class
-                    self.append(d)
-                else:
-                    # import from a list of sweep dicts in the old format
-                    self.append({k: (v['values'],
-                                     v.get('unit',''),
-                                     v.get('label', k))
-                                 for k, v in d.items()})
+        if isinstance(param, list):
+            self.add_dict_list(param)
+        elif isinstance(param, str):
+            try:
+                self.add_dict_list(eval(param))
+            except NameError:
+                if values is not None:
+                    self.add_sweep_parameter(param, values, unit, label,
+                                             dimension)
+
         while len(self) < min_length:
             self.add_sweep_dimension()
 
     def __getitem__(self, i):
         new_data = super().__getitem__(i)
         if type(i) == slice:
-            new_data = self.cast_init(new_data)
+            new_data = self.__class__(new_data)
         return new_data
+
+    def add_dict_list(self, dict_list):
+        for d in deepcopy(dict_list):
+            if len(d) == 0 or isinstance(list(d.values())[0], tuple):
+                # assume that dicts have the same format as this class
+                self.append(d)
+            else:
+                # import from a list of sweep dicts in the old format
+                self.append({k: (v['values'],
+                                 v.get('unit', ''),
+                                 v.get('label', k))
+                             for k, v in d.items()})
 
     def add_sweep_parameter(self, param_name, values, unit='', label=None,
                             dimension=-1):
@@ -309,20 +317,3 @@ class SweepPoints(list):
             if param_name in self[dim]:
                 return dim
         return None
-
-    @staticmethod
-    def cast_init(sweep_points):
-        """
-        Recreates a SweepPoints object from a string representation of
-            SweepPoints, or a list of dicts.
-        Avoids having "eval" statements throughout the codebase.
-        Args:
-            sweep_points: string representation of the SweepPoints or
-                a list of dicts
-
-        Returns: SweepPoints object
-        """
-        if isinstance(sweep_points, str):
-            return SweepPoints(from_dict_list=eval(sweep_points))
-        else:
-            return SweepPoints(from_dict_list=sweep_points)

--- a/pycqed/measurement/sweep_points.py
+++ b/pycqed/measurement/sweep_points.py
@@ -64,12 +64,11 @@ class SweepPoints(list):
         if isinstance(param, list):
             self.add_dict_list(param)
         elif isinstance(param, str):
-            try:
+            if values is not None:
+                self.add_sweep_parameter(param, values, unit, label,
+                                         dimension)
+            else:
                 self.add_dict_list(eval(param))
-            except NameError:
-                if values is not None:
-                    self.add_sweep_parameter(param, values, unit, label,
-                                             dimension)
 
         while len(self) < min_length:
             self.add_sweep_dimension()
@@ -88,7 +87,10 @@ class SweepPoints(list):
     def add_dict_list(self, dict_list):
         """
         Append the dicts in dict_list to self.
-        :param dict_list: list of dictionaries in the format of this class
+        :param dict_list: list of dictionaries in the format of this class, or
+            in the legacy format {param_name: {'values': ...,
+                                               'unit': ...,
+                                               'label': ...}}
         """
         for d in deepcopy(dict_list):
             if len(d) == 0 or isinstance(list(d.values())[0], tuple):

--- a/pycqed/measurement/sweep_points.py
+++ b/pycqed/measurement/sweep_points.py
@@ -79,9 +79,12 @@ class SweepPoints(list):
         :param i: element or slice
         :return: element or new SweepPoints instance
         """
-        new_data = super().__getitem__(i)
-        if type(i) == slice:
-            new_data = self.__class__(new_data)
+        if isinstance(i, str):
+            new_data = self.get_sweep_params_property('values', 'all', i)
+        else:
+            new_data = super().__getitem__(i)
+            if isinstance(i, slice):
+                new_data = self.__class__(new_data)
         return new_data
 
     def add_dict_list(self, dict_list):


### PR DESCRIPTION
Changes
- removes SweepPoints.cast_init by implementing the logic from there in the __init__.
- removes support for from_dict_list
- updates all calls to SweepPoints.cast_init and SweepPoints(from_dict_list) throughout the framework
