### PR TITLE
BufferedCZPulse: reference to self.algorithm_time()

### DIFF
--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -507,8 +507,8 @@ class BufferedCZPulse(pulse.Pulse):
             wave *= (tvals >= tvals[0] + buffer_start)
             wave *= (tvals < tvals[0] + buffer_start + pulse_length)
         else:
-            tstart = tvals[0] + buffer_start
-            tend = tvals[0] + buffer_start + pulse_length
+            tstart = self.algorithm_time() + buffer_start
+            tend = tstart + pulse_length
             scaling = 1 / np.sqrt(2) / self.gaussian_filter_sigma
             wave = 0.5 * (sp.special.erf(
                 (tvals - tstart) * scaling) - sp.special.erf(

--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -504,8 +504,8 @@ class BufferedCZPulse(pulse.Pulse):
 
         if self.gaussian_filter_sigma == 0:
             wave = np.ones_like(tvals) * amp
-            wave *= (tvals >= tvals[0] + buffer_start)
-            wave *= (tvals < tvals[0] + buffer_start + pulse_length)
+            wave *= (tvals >= self.algorithm_time() + buffer_start)
+            wave *= (tvals < self.algorithm_time() + buffer_start + pulse_length)
         else:
             tstart = self.algorithm_time() + buffer_start
             tend = tstart + pulse_length


### PR DESCRIPTION
BufferedCZPulse: reference to self.algorithm_time()
This does not influence normal waveform generation in segment, but allows to delay the pulse when considering a single pulse.