### PR TITLE
Various fixes and enhancements in analysis 

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -425,7 +425,7 @@ class BaseDataAnalysis(object):
     @staticmethod
     def add_measured_data(raw_data_dict, compression_factor=1,
                           sweep_points=None, cal_points=None,
-                          prep_params=None, soft_sweep_filter=None):
+                          prep_params=None, soft_sweep_mask=None):
         """
         Formats measured data based on the raw data dictionary and the
         soft and hard sweep points.
@@ -552,14 +552,14 @@ class BaseDataAnalysis(object):
                         measured_data = np.reshape(tmp_data, (ssl, hsl)).T
                     else:
                         measured_data = np.reshape(data[i], (ssl, hsl)).T
-                    if soft_sweep_filter is not None:
-                        measured_data = measured_data[:, soft_sweep_filter]
+                    if soft_sweep_mask is not None:
+                        measured_data = measured_data[:, soft_sweep_mask]
                 else:
                     measured_data = data[i]
                 raw_data_dict['measured_data'][ro_ch] = measured_data
-        if soft_sweep_filter is not None:
+        if soft_sweep_mask is not None:
             raw_data_dict['soft_sweep_points'] = raw_data_dict[
-                'soft_sweep_points'][soft_sweep_filter]
+                'soft_sweep_points'][soft_sweep_mask]
         return raw_data_dict
 
     def extract_data(self):
@@ -610,8 +610,8 @@ class BaseDataAnalysis(object):
                 SweepPoints(self.get_param_value('sweep_points')),
                 cp, self.get_param_value('preparation_params',
                                          default_value=dict()),
-                soft_sweep_filter=self.get_param_value(
-                    'soft_sweep_filter', None))
+                soft_sweep_mask=self.get_param_value(
+                    'soft_sweep_mask', None))
         else:
             temp_dict_list = []
             self.metadata = [rd['exp_metadata'] for
@@ -624,8 +624,8 @@ class BaseDataAnalysis(object):
                     self.add_measured_data(
                         rd_dict,
                         self.get_param_value('compression_factor', 1, i),
-                        soft_sweep_filter=self.get_param_value(
-                            'soft_sweep_filter', None)
+                        soft_sweep_mask=self.get_param_value(
+                            'soft_sweep_mask', None)
                     ),)
             self.raw_data_dict = tuple(temp_dict_list)
 

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -439,6 +439,10 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
 
         # create projected_data_dict
         self.data_to_fit = deepcopy(self.get_param_value('data_to_fit', {}))
+        if not len(self.data_to_fit):
+            # if data_to_fit not specified, set it to 'pe'
+            self.data_to_fit = {qbn: 'pe' for qbn in self.qb_names}
+
         # TODO: Steph 15.09.2020
         # This is a hack to allow list inside data_to_fit. These lists are
         # currently only supported by MultiCZgate_CalibAnalysis

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -1185,6 +1185,7 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                     'xunit': xunit,
                     'ylabel': ylabel,
                     'yunit': yunit,
+                    'zrange': self.get_param_value('zrange', None),
                     'title': title,
                     'clabel': data_axis_label}
         else:

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -438,8 +438,8 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
             default_value='cal_states' if self.rotate else 'no_rotation')
 
         # create projected_data_dict
-        self.data_to_fit = deepcopy(self.get_param_value('data_to_fit', {}))
-        if not len(self.data_to_fit):
+        self.data_to_fit = deepcopy(self.get_param_value('data_to_fit'))
+        if self.data_to_fit is None:
             # if data_to_fit not specified, set it to 'pe'
             self.data_to_fit = {qbn: 'pe' for qbn in self.qb_names}
 

--- a/pycqed/measurement/multi_qubit_module.py
+++ b/pycqed/measurement/multi_qubit_module.py
@@ -535,7 +535,8 @@ def measure_ssro(dev, qubits, states=('g', 'e'), n_shots=10000, label=None,
                          "preparation_params": prep_params,
                          "all_states_combinations": all_states_combinations,
                          "n_shots": n_shots,
-                         "channel_map": channel_map
+                         "channel_map": channel_map,
+                         "data_to_fit": {}
                          })
     df = get_multiplexed_readout_detector_functions(
             qubits, nr_shots=n_shots)['int_log_det']


### PR DESCRIPTION
- bugfix BaseDataAnalysis: rearrange data properly when using sequence compression with SSRO
- BaseDataAnalysis: allow analyzing only a subset of the soft sweep points (This can be used by passing a boolean array soft_sweep_mask in the options dict.)
- tda: added possibility to set zrange of 2D plots via a param value
- tda: set default value for self.data_to_fit and allow to explicitly pass an empty data_to_fit dict (plus related change in measure_ssro)

Inviting @stephlazar to review.
FYI @nathlacroix @antsr 