### PR TITLE
New functions for loading fluxline predistortion filters

### DIFF
--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -3830,7 +3830,7 @@ class QuDev_transmon(Qubit):
         Configures the fluxline distortion in a pulsar object according to the
         settings in the parameter flux_distortion of the qubit object.
 
-        :param pulse: the pulsar object. If None, self.find_instrument is
+        :param pulsar: the pulsar object. If None, self.find_instrument is
             used to find an obejct called 'Pulsar'.
         :param datadir: path to the pydata directory. If None,
             self.find_instrument is used to find an obejct called 'MC' and
@@ -3843,41 +3843,9 @@ class QuDev_transmon(Qubit):
         flux_distortion = deepcopy(self.DEFAULT_FLUX_DISTORTION)
         flux_distortion.update(self.flux_distortion())
 
-        filterCoeffs = {}
-        for fclass in 'IIR', 'FIR':
-            filterCoeffs[fclass] = []
-            for f in flux_distortion[f'{fclass}_filter_list']:
-                if f['type'] == 'Gaussian':
-                    coeffs = fl_predist.gaussian_filter_kernel(
-                        f.get('sigma', 1e-9),
-                        f.get('nr_sigma', 40),
-                        f.get('dt', 1 / pulsar.clock(
-                            channel=self.flux_pulse_channel())))
-                elif f['type'] == 'csv':
-                    filename = os.path.join(datadir,
-                                            f['filename'].lstrip('\\'))
-                    if fclass == 'IIR':
-                        coeffs = fl_predist.import_iir(filename)
-                    else:
-                        coeffs = np.loadtxt(filename)
-                else:
-                    raise KeyError(f"Unknown filter type {f['type']}")
-                filterCoeffs[fclass].append(coeffs)
-
-        if len(filterCoeffs['FIR']) > 0:
-            filterCoeffs['FIR'] = [
-                fl_predist.combine_FIR_filters(filterCoeffs['FIR'])]
-        else:
-            del filterCoeffs['FIR']
-        if len(filterCoeffs['IIR']) > 1:
-            log.warning('For now, only one IIR filter can be used. Taking '
-                        'the last one.')
-        if len(filterCoeffs['IIR']) > 0:
-            filterCoeffs['IIR'] = filterCoeffs['IIR'][-1]
-            fl_predist.scale_and_negate_IIR(filterCoeffs['IIR'],
-                                 flux_distortion['scale_IIR'])
-        else:
-            del filterCoeffs['IIR']
+        filterCoeffs = fl_predist.process_filter_coeffs_dict(
+            flux_distortion, datadir=datadir,
+            default_dt=1 / pulsar.clock(channel=self.flux_pulse_channel()))
 
         pulsar.set(f'{self.flux_pulse_channel()}_distortion_dict',
                    filterCoeffs)

--- a/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
+++ b/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
@@ -133,7 +133,6 @@ def convert_expmod_to_IIR(expmod, dt, inverse_IIR=True):
         b = [i[1] for i in iir]
     else:
         A, B, tau = expmod
-        print(A, B, tau )
         if 1 / tau < 1e-14:
             a, b = np.array([1, -1]), np.array([A + B, -(A + B)])
         else:
@@ -224,7 +223,6 @@ def process_filter_coeffs_dict(flux_distortion, datadir=None, default_dt=None):
             # append if needed
             filterCoeffs[fclass] = [[[a], [b]] for a, b in zip(
                 filterCoeffs['IIR'][0], filterCoeffs['IIR'][1])]
-            print(filterCoeffs[fclass])
         for f in flux_distortion.get(f'{fclass}_filter_list', []):
             if f['type'] == 'Gaussian' and fclass == 'FIR':
                 coeffs = gaussian_filter_kernel(f.get('sigma', 1e-9),
@@ -261,8 +259,6 @@ def process_filter_coeffs_dict(flux_distortion, datadir=None, default_dt=None):
     else:
         del filterCoeffs['FIR']
     if len(filterCoeffs['IIR']) > 0:
-        print(filterCoeffs['IIR'])
-        print([i[0] for i in filterCoeffs['IIR']])
         filterCoeffs['IIR'] = [
             np.concatenate([i[0] for i in filterCoeffs['IIR']]),
             np.concatenate([i[1] for i in filterCoeffs['IIR']])]

--- a/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
+++ b/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
@@ -1,6 +1,8 @@
 import numpy as np
 import scipy.signal as signal
 import logging
+import os
+from copy import deepcopy
 
 def import_iir(filename):
     """
@@ -106,3 +108,164 @@ def combine_FIR_filters(kernels):
         return kernel_combined
     else:
         return kernels
+
+
+def convert_expmod_to_IIR(expmod, dt, inverse_IIR=True):
+    """
+    Convert an exponential model A + B * exp(- t/tau) (or a list of such
+    models) to a first-order IIR filter (or a list of such filters).
+
+    :param expmod: list of exponential models  in the form
+        [[A_0, B_0, tau_0], ... ], or a single exponential model
+        [A_0, B_0, tau_0].
+    :param dt: (float) AWG sampling period
+    :param inverse_IIR: (bool, default: True) whether the IIR filters inverting
+        the exponential model should be returned.
+
+    :return: A list of IIR filter coefficients in the form
+        [aIIRfilterList, bIIRfilterList] according to the definition in
+        filter_iir(). If expmod is a single exponential model, a single
+        filter is returned in the form [a, b].
+    """
+    if hasattr(expmod[0], '__iter__'):
+        iir = [convert_expmod_to_IIR(e, dt, inverse_IIR) for e in expmod]
+        a = [i[0] for i in iir]
+        b = [i[1] for i in iir]
+    else:
+        A, B, tau = expmod
+        print(A, B, tau )
+        if 1 / tau < 1e-14:
+            a, b = np.array([1, -1]), np.array([A + B, -(A + B)])
+        else:
+            a = np.array(
+                [(A + (A + B) * tau * 2 / dt), (A - (A + B) * tau * 2 / dt)])
+            b = np.array([1 + tau * 2 / dt, 1 - tau * 2 / dt])
+        if not inverse_IIR:
+            a, b = b, a
+        b = b / a[0]
+        a = a / a[0]
+    return [a, b]
+
+
+def convert_IIR_to_expmod(filter_coeffs, dt, inverse_IIR=True):
+    """
+    Convert a first-order IIR filter (or a list of such filters) to an
+    exponential model A + B * exp(- t/tau) (or a list of such models).
+
+    :param filter_coeffs: IIR coefficients in the form
+        [aIIRfilterList, bIIRfilterList] according to the definition in
+        filter_iir(). Instead of a list, also single filter is accepted, i.e.,
+        [a, b] will be interpreted as [[a], [b]].
+    :param dt: (float) AWG sampling period
+    :param inverse_IIR: (bool, default: True) whether the IIR filters should
+        be interpreted as the filters inverting the exponential model
+
+    :return: A list of exponential models is returned in the form
+        [[A_0, B_0, tau_0], ... ], or a single exponential model
+        [A_0, B_0, tau_0] if filter_coeffs are of the form [a, b].
+    """
+    if hasattr(filter_coeffs[0][0], '__iter__'):
+        expmod = [convert_IIR_to_expmod([a, b], dt, inverse_IIR) for [a, b] in
+                  zip(filter_coeffs[0], filter_coeffs[1])]
+    else:
+        [a, b] = filter_coeffs
+        if not inverse_IIR:
+            a, b = b, a
+            b = b / a[0]
+            a = a / a[0]
+        gamma = np.mean(b)
+        if np.abs(gamma) < 1e-14:
+            A, B, tau =  1, 0, np.inf
+        else:
+            a_, b_ = a / gamma, b / gamma
+            A = 1 / 2 * (a_[0] + a_[1])
+            tau = 1 / 2 * (b_[0] - b_[1]) * dt / 2
+            B = 1 / 2 * (a_[0] - a_[1]) * dt / (2 * tau) - A
+        expmod = [A, B, tau]
+    return expmod
+
+
+def process_filter_coeffs_dict(flux_distortion, datadir=None, default_dt=None):
+    """
+    Prepares a distortion dictionary that can be stored into pulsar
+    {AWG}_{channel}_distortion_dict based on information provided in a
+    dictionary.
+
+    :param flux_distortion: (dict) A dictionary of the format defined in
+        QuDev_transmon.DEFAULT_FLUX_DISTORTION. In particular, the following
+        keys FIR_filter_list and IIR_filter are processed by this function.
+        They are list of dicts with a key 'type' and further keys.
+        type 'csv': load filter from the file specified under the key
+            'filename'. In case of an IIR filter, the filter will in
+            addition be scaled by the value in the key 'scale_IIR'.
+        type 'Gaussian': can be used for FIR filters. Gaussian kernel with
+            parameters 'sigma', 'nr_sigma', and 'dt' specified in the
+            respective keys. See gaussian_filter_kernel()
+        type 'expmod': can be used for IIR filters. A filter that inverts an
+            exponential model specified by the keys 'A', 'B', 'tau', and 'dt'.
+            See convert_expmod_to_IIR().
+        If flux_distortion in addition contains the keys FIR and/or IIR,
+        the filters specified as described above will be appended to those
+        already existing in FIR/IIR.
+        If flux_distortion is already in the format to be stored in pulsar,
+        it is returned unchanged.
+    :param datadir: (str) base dir for loading csv files. If None,
+        it is assumed that the specified filename includes the full path.
+    :param default_dt: (float) AWG sampling period to be used in cases where
+        'dt' is needed, but not specified in a filter dict.
+
+    """
+
+    filterCoeffs = {}
+    for fclass in 'IIR', 'FIR':
+        filterCoeffs[fclass] = flux_distortion.get(fclass, [])
+        if fclass == 'IIR' and len(filterCoeffs[fclass]) > 1:
+            # convert coefficient lists into list of filters so that we can
+            # append if needed
+            filterCoeffs[fclass] = [[[a], [b]] for a, b in zip(
+                filterCoeffs['IIR'][0], filterCoeffs['IIR'][1])]
+            print(filterCoeffs[fclass])
+        for f in flux_distortion.get(f'{fclass}_filter_list', []):
+            if f['type'] == 'Gaussian' and fclass == 'FIR':
+                coeffs = gaussian_filter_kernel(f.get('sigma', 1e-9),
+                                                f.get('nr_sigma', 40),
+                                                f.get('dt', default_dt))
+            elif f['type'] == 'expmod' and fclass == 'IIR':
+                expmod = f.get('expmod', None)
+                if expmod is None:
+                    expmod = [f.get('A'), f.get('B'), f.get('tau')]
+                if not hasattr(expmod[0], '__iter__'):
+                    expmod = [expmod]
+                coeffs = convert_expmod_to_IIR(expmod,
+                                               dt=f.get('dt', default_dt))
+            elif f['type'] == 'csv':
+                if datadir is not None:
+                    filename = os.path.join(datadir,
+                                            f['filename'].lstrip('\\'))
+                else:
+                    filename = f['filename']
+                if fclass == 'IIR':
+                    coeffs = import_iir(filename)
+                    scale_and_negate_IIR(
+                        coeffs,
+                        f.get('scale_IIR', flux_distortion['scale_IIR']))
+                else:
+                    coeffs = np.loadtxt(filename)
+            else:
+                raise NotImplementedError(f"Unknown filter type {f['type']}")
+            filterCoeffs[fclass].append(coeffs)
+
+    if len(filterCoeffs['FIR']) > 0:
+        filterCoeffs['FIR'] = [
+            combine_FIR_filters(filterCoeffs['FIR'])]
+    else:
+        del filterCoeffs['FIR']
+    if len(filterCoeffs['IIR']) > 0:
+        print(filterCoeffs['IIR'])
+        print([i[0] for i in filterCoeffs['IIR']])
+        filterCoeffs['IIR'] = [
+            np.concatenate([i[0] for i in filterCoeffs['IIR']]),
+            np.concatenate([i[1] for i in filterCoeffs['IIR']])]
+    else:
+        del filterCoeffs['IIR']
+    return filterCoeffs

--- a/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
+++ b/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
@@ -139,6 +139,8 @@ def convert_expmod_to_IIR(expmod, dt, inverse_IIR=True):
             a = sympy.symbols(','.join([f'a{i}' for i in range(N + 1)]))
             tau_s = sympy.symbols(','.join([f'tau{i + 1}' for i in range(
                 N)]))
+            if N == 1:
+                tau_s = [tau_s]
             T = sympy.symbols('T')
             z = sympy.symbols('z')
             p = 2 / T * (1 - 1 / z) / (1 + 1 / z)

--- a/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
+++ b/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
@@ -133,7 +133,7 @@ def convert_expmod_to_IIR(expmod, dt, inverse_IIR=True):
         b = [i[1] for i in iir]
     else:
         A, B, tau = expmod
-        if isinstance(tau, list):  # sum of exp mod
+        if np.array(tau).ndim > 0:  # sum of exp mod
             import sympy
             N = len(tau)
             a = sympy.symbols(','.join([f'a{i}' for i in range(N + 1)]))

--- a/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
+++ b/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
@@ -128,17 +128,25 @@ def convert_expmod_to_IIR(expmod, dt, inverse_IIR=True, direct=False):
     :param dt: (float) AWG sampling period
     :param inverse_IIR: (bool, default: True) whether the IIR filters inverting
         the exponential model should be returned.
+    :param direct: (bool, default: False) whether higher-order IIR filters
+        should be implemented in directly. The default is to implement
+        them as second-order sections.
 
     :return: A list of IIR filter coefficients in the form
         [aIIRfilterList, bIIRfilterList] according to the definition in
-        filter_iir(). If expmod is a single exponential model, a single
+        filter_iir(). If expmod is a single first-order exponential model (or a
+        single higher-order exponential model with direct=True), a single
         filter is returned in the form [a, b].
     """
     if hasattr(expmod[0], '__iter__'):
-        # FIXME: probably this does not work for multiple sos filter lists
-        iir = [convert_expmod_to_IIR(e, dt, inverse_IIR) for e in expmod]
-        a = [i[0] for i in iir]
-        b = [i[1] for i in iir]
+        iir = [convert_expmod_to_IIR(e, dt, inverse_IIR=inverse_IIR,
+                                     direct=direct) for e in expmod]
+        # Checking whether i[0][0] is iterable is needed because a single expmod
+        # might be converted to multiple IIRs (second-order sections, SOS)
+        a = np.concatenate(
+            [[i[0]] if not hasattr(i[0][0], '__iter__') else i[0] for i in iir])
+        b = np.concatenate(
+            [[i[1]] if not hasattr(i[1][0], '__iter__') else i[1] for i in iir])
     else:
         A, B, tau = expmod
         if np.array(tau).ndim > 0:  # sum of exp mod

--- a/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
+++ b/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
@@ -293,7 +293,8 @@ def process_filter_coeffs_dict(flux_distortion, datadir=None, default_dt=None):
                 if not hasattr(expmod[0], '__iter__'):
                     expmod = [expmod]
                 coeffs = convert_expmod_to_IIR(expmod,
-                                               dt=f.get('dt', default_dt))
+                                               dt=f.get('dt', default_dt),
+                                               direct=f.get('direct', False))
             elif f['type'] == 'csv':
                 if datadir is not None:
                     filename = os.path.join(datadir,

--- a/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
+++ b/pycqed/measurement/waveform_control/fluxpulse_predistortion.py
@@ -155,7 +155,7 @@ def convert_expmod_to_IIR(expmod, dt, inverse_IIR=True, direct=False):
             a = [sp.Rational(a) for a in [A] + list(B)]
             tau_s = [sp.Rational(t / 1e-9) * 1e-9 for t in list(tau)]
             # In the next line, going via the reciprocal value is more precise
-            # since we usually specify dt a 1 over sampling frequency.
+            # since we usually specify dt as 1 over sampling frequency.
             T = 1 / sp.Rational(f"{1 / dt}")
             if direct:
                 z = sp.symbols('z')


### PR DESCRIPTION
This PR extends the module fluxpulse_predistortion with new features for IIR filters:
- functions to convert between exponential models and IIR coefficients
- move functionality from QuDev_transmon.set_distortion_in_pulsar to a new function in this module
- allow specifying an exponential model in the distortion_dict instead of loading the IIR coefficients from a file
- support for higher order IIR filters (second-order sections or direct implementation)

Inviting @RichardBoell to review
FYI @antsr @nathlacroix @stephlazar 