### PR TITLE
Timer framework to analyze run time of code and measurements

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -394,6 +394,11 @@ class BaseDataAnalysis(object):
                                 raw_data_dict_ts[save_par] = \
                                     self.get_hdf_datafile_param_value(
                                         data_file[group_name], par_name)
+                            elif par_name in list(data_file[group_name].keys()) or\
+                                    (par_name == "Timers" and group_name == "Timers"):
+                                raw_data_dict_ts[save_par] = \
+                                    read_dict_from_hdf5({}, data_file[
+                                        group_name])
                     else:
                         group_name = '/'.join(file_par.split('.')[:-1])
                         par_name = file_par.split('.')[-1]

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -6,6 +6,7 @@ import itertools
 import matplotlib as mpl
 from collections import OrderedDict, defaultdict
 
+from pycqed.utilities.timer import Timer
 from sklearn.mixture import GaussianMixture as GM
 from sklearn.tree import DecisionTreeClassifier as DTC
 
@@ -8036,3 +8037,36 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                     'color': 'r',
                     'linestyle': '-',
                     'marker': 'x'}
+
+class RunTimeAnalysis(ba.BaseDataAnalysis):
+
+    def __init__(self,
+                 label: str = '',
+                 t_start: str = None, t_stop: str = None, data_file_path: str = None,
+                 options_dict: dict = None, extract_only: bool = False,
+                 do_fitting: bool = True, auto=True,
+                 params_dict=None, numeric_params=None, **kwargs):
+
+        super().__init__(t_start=t_start, t_stop=t_stop, label=label,
+                         data_file_path=data_file_path,
+                         options_dict=options_dict,
+                         extract_only=extract_only,
+                         do_fitting=do_fitting, **kwargs)
+
+
+        if not hasattr(self, "job"):
+            self.create_job(t_start=t_start, t_stop=t_stop,
+                            label=label, data_file_path=data_file_path,
+                            do_fitting=do_fitting, options_dict=options_dict,
+                            extract_only=extract_only, params_dict=params_dict,
+                            numeric_params=numeric_params, **kwargs)
+        self.params_dict = {f"{Timer.HDF_GRP_NAME}": f"{Timer.HDF_GRP_NAME}",
+                            "repetition_rate": "Instrument settings/TriggerDevice.pulse_period",
+                            }
+
+
+        if auto:
+            self.run_analysis()
+
+    def process_data(self):
+        pass

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -8100,8 +8100,9 @@ class RunTimeAnalysis(ba.BaseDataAnalysis):
             self.figs['timer_all'] = tm_mod.multi_plot(self.timers.values(),
                                                        **plot_kws)
 
-    def bare_measurement_timer(self, ref_time=None):
-        bmtime = self.bare_measurement_time()
+    def bare_measurement_timer(self, ref_time=None,
+                               checkpoint='bare_measurement', **kw):
+        bmtime = self.bare_measurement_time(**kw)
         bmtimer = tm_mod.Timer('BareMeasurement', auto_start=False)
         if ref_time is None:
             try:
@@ -8118,32 +8119,43 @@ class RunTimeAnalysis(ba.BaseDataAnalysis):
 
         # TODO add more options of how to distribute the bm time in the timer
         #  (not only start stop but e.g. distribute it)
-        bmtimer.checkpoint("BareMeasurement.bare_measurement.start",
+        bmtimer.checkpoint(f"BareMeasurement.{checkpoint}.start",
                            values=[ref_time], log_init=False)
-        bmtimer.checkpoint("BareMeasurement.bare_measurement.end",
+        bmtimer.checkpoint(f"BareMeasurement.{checkpoint}.end",
                            values=[ ref_time + dt.timedelta(seconds=bmtime)],
                            log_init=False)
 
         return bmtimer
 
-    def bare_measurement_time(self):
+    def bare_measurement_time(self, nr_averages=None, repetition_rate=None,
+                              count_nan_measurements=False):
         det_metadata = self.metadata.get("Detector Metadata", None)
-        nr_averages = None
         if det_metadata is not None:
             # multi detector function: look for child "detectors"
             # assumes at least 1 child and that all children have the same
             # number of averages
             det = list(det_metadata.get('detectors', {}).values())[0]
-            nr_averages = det.get('nr_averages', det.get('nr_shots', None))
+            if nr_averages is None:
+                nr_averages = det.get('nr_averages', det.get('nr_shots', None))
         if nr_averages is None:
             raise ValueError('Could not extract nr_averages/nr_shots from hdf file.'
                              'Please specify "nr_averages" in options_dict.')
         n_hsp = len(self.raw_data_dict['hard_sweep_points'])
         n_ssp = len(self.raw_data_dict.get('soft_sweep_points', [0]))
+        if repetition_rate is None:
+            repetition_rate = self.raw_data_dict["repetition_rate"]
+        if count_nan_measurements:
+            perc_meas = 1
+        else:
+            # When sweep points are skipped, data is missing in all columns
+            # Thus, we can simply check in the first column.
+            vals = list(self.raw_data_dict['measured_data'].values())[0]
+            perc_meas = 1 - np.sum(np.isnan(vals)) / np.prod(vals.shape)
+        return self._bare_measurement_time(n_ssp, n_hsp, repetition_rate,
+                                           nr_averages, perc_meas)
 
-        return self._bare_measurement_time(n_ssp, n_hsp,
-                                          self.raw_data_dict["repetition_rate"],
-                                    nr_averages)
     @staticmethod
-    def _bare_measurement_time(n_ssp, n_hsp, repetition_rate, nr_averages):
-        return n_ssp * n_hsp * repetition_rate * nr_averages
+    def _bare_measurement_time(n_ssp, n_hsp, repetition_rate, nr_averages,
+                               percentage_measured):
+        return n_ssp * n_hsp * repetition_rate * nr_averages \
+               * percentage_measured

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -13,6 +13,8 @@ from pycqed.analysis import measurement_analysis as ma
 from pycqed.utilities.general import temporary_value
 import logging
 
+from pycqed.utilities.timer import Timer
+
 log = logging.getLogger(__name__)
 
 
@@ -191,6 +193,7 @@ class T1FrequencySweep(CalibBuilder):
         return self.sequential_blocks(f't1 flux pulse {qubit_name}',
                                       [pb, pp, fp])
 
+    @Timer()
     def run_analysis(self, **kw):
         """
         Runs analysis and stores analysis instance in self.analysis.
@@ -365,6 +368,7 @@ class FluxPulseScope(ParallelLOSweepExperiment):
 
         return b
 
+    @Timer()
     def run_analysis(self, analysis_kwargs=None, **kw):
         """
         Runs analysis and stores analysis instances in self.analysis.
@@ -765,6 +769,7 @@ class Cryoscope(CalibBuilder):
                                    unit, label, dimension=1)
         self.sweep_points.update(sp)
 
+    @Timer()
     def run_analysis(self, analysis_kwargs=None, **kw):
         """
         Runs analysis and stores analysis instances in self.analysis.
@@ -852,6 +857,7 @@ class FluxPulseAmplitudeSweep(ParallelLOSweepExperiment):
 
         return b
 
+    @Timer()
     def run_analysis(self, analysis_kwargs=None, **kw):
         """
         Runs analysis and stores analysis instances in self.analysis.

--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -513,12 +513,14 @@ class UHFQC_Base(Hard_Detector):
     def poll_data(self):
         if self.AWG is not None:
             self.AWG.stop()
+            self.timer.checkpoint("UHFQC_Base.poll_data.AWG_stopped")
 
         for UHF in self.UHFs:
             UHF.set('qas_0_result_enable', 1)
 
         if self.AWG is not None:
             self.AWG.start()
+            self.timer.checkpoint("UHFQC_Base.poll_data.AWG_started")
 
         acq_paths = {UHF.name: UHF._acquisition_nodes for UHF in self.UHFs}
 
@@ -530,12 +532,14 @@ class UHFQC_Base(Hard_Detector):
                  self.UHFs}
         accumulated_time = 0
 
+        self.timer.checkpoint("UHFQC_Base.poll_data.loopstart")
         while accumulated_time < self.UHFs[0].timeout() and \
                 not all(np.concatenate(list(gotem.values()))):
             dataset = {}
             for UHF in self.UHFs:
                 if not all(gotem[UHF.name]):
                     time.sleep(0.01)
+                    self.timer.checkpoint("UHFQC_Base.poll_data.poll")
                     dataset[UHF.name] = UHF.poll(0.01)
             for UHFname in dataset.keys():
                 for n, p in enumerate(acq_paths[UHFname]):

--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -512,15 +512,15 @@ class UHFQC_Base(Hard_Detector):
     @Timer()
     def poll_data(self):
         if self.AWG is not None:
+            self.timer.checkpoint("UHFQC_Base.poll_data.AWG_restart.start")
             self.AWG.stop()
-            self.timer.checkpoint("UHFQC_Base.poll_data.AWG_stopped")
 
         for UHF in self.UHFs:
             UHF.set('qas_0_result_enable', 1)
 
         if self.AWG is not None:
             self.AWG.start()
-            self.timer.checkpoint("UHFQC_Base.poll_data.AWG_started")
+            self.timer.checkpoint("UHFQC_Base.poll_data.AWG_restart.end")
 
         acq_paths = {UHF.name: UHF._acquisition_nodes for UHF in self.UHFs}
 
@@ -532,14 +532,13 @@ class UHFQC_Base(Hard_Detector):
                  self.UHFs}
         accumulated_time = 0
 
-        self.timer.checkpoint("UHFQC_Base.poll_data.loopstart")
+        self.timer.checkpoint("UHFQC_Base.poll_data.loop.start")
         while accumulated_time < self.UHFs[0].timeout() and \
                 not all(np.concatenate(list(gotem.values()))):
             dataset = {}
             for UHF in self.UHFs:
                 if not all(gotem[UHF.name]):
                     time.sleep(0.01)
-                    self.timer.checkpoint("UHFQC_Base.poll_data.poll")
                     dataset[UHF.name] = UHF.poll(0.01)
             for UHFname in dataset.keys():
                 for n, p in enumerate(acq_paths[UHFname]):
@@ -552,6 +551,7 @@ class UHFQC_Base(Hard_Detector):
                                 self.UHF_map[UHFname]].nr_sweep_points:
                                 gotem[UHFname][n] = True
             accumulated_time += 0.01 * len(self.UHFs)
+        self.timer.checkpoint("UHFQC_Base.poll_data.loop.end")
 
         if not all(np.concatenate(list(gotem.values()))):
             for UHF in self.UHFs:

--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 import time
 from string import ascii_uppercase
 from pycqed.analysis import analysis_toolbox as a_tools
+from pycqed.utilities.timer import Timer
 from qcodes.instrument.parameter import _BaseParameter
 from qcodes.instrument.base import Instrument
 import logging
@@ -27,6 +28,7 @@ class Detector_Function(object):
         self.value_units = ['arb. units', 'arb. units']
         # to be used by MC.get_percdone()
         self.acq_data_len_scaling = 1
+        self.timer = Timer(self.name)
 
     def set_kw(self, **kw):
         '''
@@ -609,6 +611,7 @@ class UHFQC_multi_detector(UHFQC_Base):
             self.value_names += ['correlation']
             self.value_units += ['']
 
+    @Timer()
     def prepare(self, sweep_points):
         for d in self.detectors:
             d.prepare(sweep_points)
@@ -730,7 +733,7 @@ class UHFQC_input_average_detector(UHFQC_Base):
         # Verified January 2018 by Xavi
         return raw_data
 
-
+    @Timer()
     def prepare(self, sweep_points):
         if self.AWG is not None:
             self.AWG.stop()

--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -509,6 +509,7 @@ class UHFQC_Base(Hard_Detector):
         self.UHF_map = {UHF.name: i
                    for UHF, i in zip(self.UHFs, range(len(self.detectors)))}
 
+    @Timer()
     def poll_data(self):
         if self.AWG is not None:
             self.AWG.stop()

--- a/pycqed/measurement/measurement_control.py
+++ b/pycqed/measurement/measurement_control.py
@@ -306,7 +306,12 @@ class MeasurementControl(Instrument):
                     for i, sweep_function in enumerate(self.sweep_functions):
                         swf_sweep_points = sweep_points[:, i]
                         val = swf_sweep_points[start_idx]
+                        # prepare in 2D sweeps is done in set_parameters (though not always
+                        # for first upload). Therefore, a common checkpoint is used
+                        # in the timer to collect upload times in a single place
+                        self.timer.checkpoint("MeasurementControl.measure.prepare.start")
                         sweep_function.set_parameter(val)
+                        self.timer.checkpoint("MeasurementControl.measure.prepare.end")
                     self.detector_function.prepare(
                         sweep_points=sweep_points[
                             start_idx:start_idx+self.xlen, 0])

--- a/pycqed/measurement/measurement_control.py
+++ b/pycqed/measurement/measurement_control.py
@@ -1,5 +1,8 @@
 import types
 import logging
+
+from pycqed.utilities.timer import Timer
+
 log = logging.getLogger(__name__)
 import time
 from copy import deepcopy
@@ -128,6 +131,7 @@ class MeasurementControl(Instrument):
         self._persist_xlabs = None
         self._persist_ylabs = None
         self._analysis_display = None
+        self.timer = Timer()
 
         self.exp_metadata = {}
         self._plotmon_axes_info = None
@@ -156,7 +160,7 @@ class MeasurementControl(Instrument):
         if sweep_points is not None:
             self.set_sweep_points(np.tile(sweep_points,
                                           self.acq_data_len_scaling))
-
+    @Timer()
     def run(self, name: str=None, exp_metadata: dict=None,
             mode: str='1D', disable_snapshot_metadata: bool=False, **kw):
         '''
@@ -183,6 +187,8 @@ class MeasurementControl(Instrument):
                     accidentally leaving it off.
 
         '''
+
+        self.timer = Timer("MeasurementControl")
         # Setting to zero at the start of every run, used in soft avg
         self.soft_iteration = 0
         self.set_measurement_name(name)
@@ -255,17 +261,28 @@ class MeasurementControl(Instrument):
             result = self.dset[()]
             self.get_measurement_endtime()
             self.save_MC_metadata(self.data_object)  # timing labels etc
+            # FIXME: Nathan 2020.12.03.
+            #  save_timer could alternatively be placed in quantum Experiment,
+            #  which could make more sense semantically and would allow to get "run.end"
+            #  in the MC timer (i.e. the end of this function).
+            #  Qexp  needs to save its own timer anyway, but by having it here for now
+            #  we're sure that experiment that are not based on Qexp still have some timers
+            #  saved.
+            self.save_timers(self.data_object)
             return_dict = self.create_experiment_result_dict()
 
         self.finish(result)
         return return_dict
 
+    @Timer()
     def measure(self):
         if self.live_plot_enabled():
             self.initialize_plot_monitor()
 
+        self.timer.checkpoint("MeasurementControl.measure.prepare.start")
         for sweep_function in self.sweep_functions:
             sweep_function.prepare()
+        self.timer.checkpoint("MeasurementControl.measure.prepare.end")
 
         if (self.sweep_functions[0].sweep_control == 'soft' and
                 self.detector_function.detector_control == 'soft'):
@@ -363,6 +380,7 @@ class MeasurementControl(Instrument):
         self.update_plotmon_adaptive(force_update=True)
         return
 
+    @Timer()
     def measure_hard(self):
         new_data = np.array(self.detector_function.get_values()).T
 
@@ -1637,6 +1655,18 @@ class MeasurementControl(Instrument):
             metadata_group = data_group.create_group('Experimental Metadata')
 
         h5d.write_dict_to_hdf5(metadata, entry_point=metadata_group)
+
+    def save_timers(self, data_object, detector=True, MC=True):
+        timer_group = data_object.get(Timer.HDF_GRP_NAME)
+        if timer_group is None:
+            timer_group = data_object.create_group(Timer.HDF_GRP_NAME)
+        objects = (self.detector_function, self)
+        for obj, cond in zip(objects, (detector, MC)):
+            try:
+                obj.timer.save(timer_group)
+            except Exception:
+                log.error(f"Could not save timer for object: {obj}.")
+                traceback.print_exc()
 
     def get_percdone(self):
         percdone = self.total_nr_acquired_values / (

--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -234,6 +234,7 @@ class QuantumExperiment(CircuitBuilder):
         if len(self.mc_points) == 1:
             self.mc_points = [self.mc_points[0], []]
 
+        e = None
         with temporary_value(*self.temporary_values):
             # Perpare all involved qubits. If not available, prepare
             # all measure objects.
@@ -257,11 +258,12 @@ class QuantumExperiment(CircuitBuilder):
                 self.MC.run(name=self.label, exp_metadata=self.exp_metadata,
                             mode=mode)
             except (Exception, KeyboardInterrupt) as e:
-                self.extract_timestamp()
-                raise e
+                pass  # exception will be raised below
         self.extract_timestamp()
         if save_timers:
             self.save_timers()
+        if e is not None:
+            raise e
 
     def update_metadata(self):
         # make sure that all metadata params are up to date
@@ -331,8 +333,12 @@ class QuantumExperiment(CircuitBuilder):
 
     def autorun(self, **kw):
         if self.measure:
-            # Do not save timers here since they will be saved below.
-            self.run_measurement(save_timers=False, **kw)
+            try:
+                # Do not save timers here since they will be saved below.
+                self.run_measurement(save_timers=False, **kw)
+            except (Exception, KeyboardInterrupt) as e:
+                self.save_timers()
+                raise e
         if self.analyze:
             self.run_analysis(**kw)
         if self.callback is not None and self.callback_condition():

--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -234,7 +234,7 @@ class QuantumExperiment(CircuitBuilder):
         if len(self.mc_points) == 1:
             self.mc_points = [self.mc_points[0], []]
 
-        e = None
+        exception = None
         with temporary_value(*self.temporary_values):
             # Perpare all involved qubits. If not available, prepare
             # all measure objects.
@@ -258,12 +258,12 @@ class QuantumExperiment(CircuitBuilder):
                 self.MC.run(name=self.label, exp_metadata=self.exp_metadata,
                             mode=mode)
             except (Exception, KeyboardInterrupt) as e:
-                pass  # exception will be raised below
+                exception = e  # exception will be raised below
         self.extract_timestamp()
         if save_timers:
             self.save_timers()
-        if e is not None:
-            raise e
+        if exception is not None:
+            raise exception
 
     def update_metadata(self):
         # make sure that all metadata params are up to date

--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -216,12 +216,15 @@ class QuantumExperiment(CircuitBuilder):
                     setattr(self, param_name, param_value)
 
     @Timer()
-    def run_measurement(self, **kw):
+    def run_measurement(self, save_timers=True, **kw):
         """
         Runs a measurement. Any keyword argument passes to this function that
         is also an attribute of the QuantumExperiment class will be updated
         before starting the experiment
 
+        Args:
+            save_timers (bool): whether timers should be saved to the hdf
+            file at the end of the measurement (default: True).
         Returns:
 
         """
@@ -257,6 +260,8 @@ class QuantumExperiment(CircuitBuilder):
                 self.extract_timestamp()
                 raise e
         self.extract_timestamp()
+        if save_timers:
+            self.save_timers()
 
     def update_metadata(self):
         # make sure that all metadata params are up to date
@@ -326,7 +331,8 @@ class QuantumExperiment(CircuitBuilder):
 
     def autorun(self, **kw):
         if self.measure:
-            self.run_measurement(**kw)
+            # Do not save timers here since they will be saved below.
+            self.run_measurement(save_timers=False, **kw)
         if self.analyze:
             self.run_analysis(**kw)
         if self.callback is not None and self.callback_condition():

--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -603,7 +603,8 @@ class QuantumExperiment(CircuitBuilder):
     #     self.__dict__[name] = value
 
     def save_timers(self, quantum_experiment=True, sequence=True, segments=True, filepath=None):
-
+        if self.MC is None or self.MC.skip_measurement():
+            return
         data_file = helper_functions.open_hdf_file(self.timestamp, filepath=filepath, mode="r+")
         try:
             timer_group = data_file.get(Timer.HDF_GRP_NAME)

--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -1,7 +1,11 @@
+import traceback
+
 import numpy as np
+from pycqed.analysis_v3 import helper_functions
 
 from pycqed.measurement.waveform_control.sequence import Sequence
 from pycqed.utilities.general import temporary_value
+from pycqed.utilities.timer import Timer, Checkpoint
 from pycqed.measurement.waveform_control.circuit_builder import CircuitBuilder
 import pycqed.measurement.awg_sweep_functions as awg_swf
 from pycqed.measurement import multi_qubit_module as mqm
@@ -32,6 +36,7 @@ class QuantumExperiment(CircuitBuilder):
                  analyze=True, temporary_values=(), drive="timedomain",
                  sequences=(), sequence_function=None,
                  sequence_kwargs=None, df_kwargs=None, df_name=None,
+                 timer_kwargs=None,
                  mc_points=None, sweep_functions=(awg_swf.SegmentHardSweep,
                                                       awg_swf.SegmentSoftSweep),
                  compression_seg_lim=None, force_2D_sweep=True, callback=None,
@@ -71,6 +76,8 @@ class QuantumExperiment(CircuitBuilder):
             sequence_kwargs (dict): keyword arguments passed to the sequence_function.
                 see self._prepare_sequences()
             df_kwargs (dict): detector function keyword arguments.
+            timer_kwargs (dict): keyword arguments for timer. See pycqed.utilities.timer.
+                Timer.
             df_name (str): detector function name.
             mc_points (tuple): tuple of 2 lists with first and second dimension
                 measurement control points (previously also called sweep_points,
@@ -105,7 +112,8 @@ class QuantumExperiment(CircuitBuilder):
             **kw:
                 further keyword arguments are passed to the CircuitBuilder __init__
         """
-
+        self.timer = Timer('QuantumExperiment', **timer_kwargs if timer_kwargs is
+                                                                  not None else {})
         if qubits is None and dev is None and operation_dict is None:
             raise NotImplementedError('Experiments without qubits are not '
                                       'implemented yet. Either dev or qubits'
@@ -207,6 +215,7 @@ class QuantumExperiment(CircuitBuilder):
                 else:
                     setattr(self, param_name, param_value)
 
+    @Timer()
     def run_measurement(self, **kw):
         """
         Runs a measurement. Any keyword argument passes to this function that
@@ -297,6 +306,7 @@ class QuantumExperiment(CircuitBuilder):
                 # guess_label is called from run_measurement -> we have qubits
                 self.label += mqm.get_multi_qubit_msmt_suffix(self.meas_objs)
 
+    @Timer()
     def run_analysis(self, analysis_class=None, analysis_kwargs=None, **kw):
         """
         Launches the analysis.
@@ -321,6 +331,8 @@ class QuantumExperiment(CircuitBuilder):
             self.run_analysis(**kw)
         if self.callback is not None and self.callback_condition():
             self.callback(**kw)
+        if self.measure: # for now store timers only if creating new file
+            self.save_timers()
         return self
 
     def serialize(self, omitted_attrs=('MC', 'device', 'qubits')):
@@ -332,6 +344,7 @@ class QuantumExperiment(CircuitBuilder):
         """
         raise NotImplementedError()
 
+    @Timer()
     def _prepare_sequences(self, sequences=None, sequence_function=None,
                            sequence_kwargs=None):
         """
@@ -411,6 +424,7 @@ class QuantumExperiment(CircuitBuilder):
         # check sequence
         assert len(self.sequences) != 0, "No sequence found."
 
+    @Timer()
     def _configure_mc(self, MC=None):
         """
         Configure the measurement control (self.MC) for the measurement.
@@ -587,6 +601,52 @@ class QuantumExperiment(CircuitBuilder):
     #             raise e
     #
     #     self.__dict__[name] = value
+
+    def save_timers(self, quantum_experiment=True, sequence=True, segments=True, filepath=None):
+
+        data_file = helper_functions.open_hdf_file(self.timestamp, filepath=filepath, mode="r+")
+        try:
+            timer_group = data_file.get(Timer.HDF_GRP_NAME)
+            if timer_group is None:
+                timer_group = data_file.create_group(Timer.HDF_GRP_NAME)
+            if quantum_experiment:
+                self.timer.save(timer_group)
+
+            if sequence:
+                seq_group = timer_group.create_group('Sequences')
+                for s in self.sequences:
+                    # save sequence timers
+                    try:
+                        timer_seq_name = s.timer.name
+                        # check that name doesn't exist and it case it does, append an index
+                        # Note: normally that should not happen (not desirable)
+                        if timer_seq_name in seq_group.keys():
+                            log.warning(f"Timer with name {timer_seq_name} already "
+                                        f"exists in Sequences timers. "
+                                        f"Only last instance will be kept")
+                        s.timer.save(seq_group)
+
+                        if segments:
+                            seg_group = seq_group[timer_seq_name].create_group(timer_seq_name + ".segments")
+                            for _, seg in s.segments.items():
+                                try:
+                                    timer_seg_name = seg.timer.name
+                                    # check that name doesn't exist and it case it does, append an index
+                                    # Note: normally that should not happen (not desirable)
+                                    if timer_seg_name in seg_group.keys():
+                                        log.warning(f"Timer with name {timer_seg_name} already "
+                                                    f"exists in Segments timers. "
+                                                    f"Only last instance will be kept")
+                                    seg.timer.save(seg_group)
+                                except AttributeError:
+                                    pass
+
+                    except AttributeError:
+                        pass # in case some sequences don't have timers
+        except Exception as e:
+            data_file.close()
+            raise e
+
 
     def __repr__(self):
         return f"QuantumExperiment(dev={self.dev}, qubits={self.qubits})"

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -141,12 +141,17 @@ class Segment:
         self.add_flux_crosstalk_cancellation_channels()
         self.gen_trigger_el()
         self.add_charge_compensation()
-        # FIXME: we currently store 1e9*length because datetime does not
-        #  support nanoseconds. Find a cleaner solution.
-        self.timer.checkpoint(
-            'length.dt', log_init=False,
-            values=[datetime.datetime.fromtimestamp(
-                -1e9*np.diff(self.get_segment_start_end()))])
+        try:
+            # FIXME: we currently store 1e9*length because datetime does not
+            #  support nanoseconds. Find a cleaner solution.
+            self.timer.checkpoint(
+                'length.dt', log_init=False,
+                values=[datetime.datetime.fromtimestamp(
+                    -1e9*np.diff(self.get_segment_start_end()))])
+        except Exception as e:
+            # storing segment length is not crucial for the measurement
+            log.warning(f"Could not store segment length timer: {e}")
+
 
     def enforce_single_element(self):
         self.resolved_pulses = []

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -9,6 +9,7 @@ import numpy as np
 import math
 import logging
 
+import datetime
 from pycqed.utilities.timer import Timer
 
 log = logging.getLogger(__name__)
@@ -140,6 +141,12 @@ class Segment:
         self.add_flux_crosstalk_cancellation_channels()
         self.gen_trigger_el()
         self.add_charge_compensation()
+        # FIXME: we currently store 1e9*length because datetime does not
+        #  support nanoseconds. Find a cleaner solution.
+        self.timer.checkpoint(
+            'length.dt', log_init=False,
+            values=[datetime.datetime.fromtimestamp(
+                -1e9*np.diff(self.get_segment_start_end()))])
 
     def enforce_single_element(self):
         self.resolved_pulses = []
@@ -682,6 +689,15 @@ class Segment:
         This method returns the start of an element on an AWG in algorithm_time 
         """
         return self.element_start_end[element][awg][0]
+
+    def get_segment_start_end(self):
+        """
+        Returns the start and end of the segment in algorithm_time
+        """
+        start_end_times = np.array(
+            [[self.get_element_start(el, awg), self.get_element_end(el, awg)]
+             for awg, v in self.elements_on_awg.items() for el in v])
+        return np.max(start_end_times[:, 0]), np.min(start_end_times[:, 0])
 
     def _test_overlap(self):
         """

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -8,6 +8,9 @@
 import numpy as np
 import math
 import logging
+
+from pycqed.utilities.timer import Timer
+
 log = logging.getLogger(__name__)
 from copy import deepcopy
 import pycqed.measurement.waveform_control.pulse as bpl
@@ -46,6 +49,7 @@ class Segment:
                                       self.trigger_pars['buffer_length_start']
         self._pulse_names = set()
         self.acquisition_elements = set()
+        self.timer = Timer(self.name)
 
         for pulse_pars in pulse_pars_list:
             self.add(pulse_pars)
@@ -119,6 +123,7 @@ class Segment:
         for p in pulses:
             self.add(p)
 
+    @Timer()
     def resolve_segment(self):
         """
         Top layer method of Segment class. After having addded all pulses,
@@ -1344,6 +1349,9 @@ class Segment:
 
         # rename segment name
         self.name = new_name
+
+        # rename timer
+        self.timer.name = new_name
 
     def __deepcopy__(self, memo):
         cls = self.__class__

--- a/pycqed/measurement/waveform_control/sequence.py
+++ b/pycqed/measurement/waveform_control/sequence.py
@@ -9,6 +9,9 @@ import pycqed.measurement.waveform_control.pulsar as ps
 from collections import OrderedDict as odict
 from copy import deepcopy
 import logging
+
+from pycqed.utilities.timer import Timer
+
 log = logging.getLogger(__name__)
 
 class Sequence:
@@ -16,6 +19,8 @@ class Sequence:
     A Sequence consists of several segments, which can be played back on the 
     AWGs sequentially.
     """
+
+    RENAMING_SEPARATOR = "+"
 
     def __init__(self, name, segments=()):
         """
@@ -30,6 +35,7 @@ class Sequence:
         self.awg_sequence = {}
         self.repeat_patterns = {}
         self.extend(segments)
+        self.timer = Timer(self.name)
 
     def add(self, segment):
         if segment.name in self.segments:
@@ -46,7 +52,7 @@ class Sequence:
         for seg in segments:
             self.add(seg)
 
-
+    @Timer()
     def generate_waveforms_sequences(self, awgs=None):
         """
         Calculates and returns 

--- a/pycqed/utilities/timer.py
+++ b/pycqed/utilities/timer.py
@@ -1,0 +1,174 @@
+import numpy as np
+import datetime as dt
+import logging
+from collections import OrderedDict
+
+from pycqed.measurement.hdf5_data import write_dict_to_hdf5
+
+log = logging.getLogger(__name__)
+
+import functools
+
+
+class Timer(OrderedDict):
+    HDF_GRP_NAME = "Timers"
+    NAME_CKPT_START = "start"
+    NAME_CKPT_END = "end"
+
+    def __init__(self, name="timer", fmt="%Y-%m-%d %H:%M:%S.%f", name_separator=".",
+                 verbose=False, auto_start=True, timer=None):
+        self.fmt = fmt
+        self.name = name
+        self.name_separator = name_separator
+        self.verbose = verbose
+        if timer is not None:
+            super().__init__(timer)
+        if auto_start and timer is not None:
+            self.checkpoint(self.NAME_CKPT_START)
+
+    @staticmethod
+    def from_string(timer):
+        pass
+
+    def __call__(self, func):
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            # print(args)
+            if hasattr(args[0], "timer"):
+                args[0].timer.checkpoint(func.__qualname__ + self.name_separator + self.NAME_CKPT_START)
+            else:
+                log.warning(f'Using @Timer decorator on {args[0]} but {args[0]} has no .timer attribute.'
+                            'Time will not be logged.')
+            output = func(*args, **kwargs)
+            if hasattr(args[0], "timer"):
+                args[0].timer.checkpoint(func.__qualname__ + self.name_separator + self.NAME_CKPT_END)
+            return output
+
+        return wrapper
+
+    def __enter__(self):
+        if self.get(self.NAME_CKPT_START, None) is None:
+            # overwrite auto_start because when used in "with" statement, start must happen at beginning
+            self.checkpoint(self.NAME_CKPT_START)
+        if self.verbose:
+            lvl = log.level
+            log.setLevel(logging.INFO)
+            log.info(f'Start of {self.name}: {self[self.NAME_CKPT_START].get_start()}')
+            log.setLevel(lvl)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.checkpoint(self.NAME_CKPT_END)
+
+        if self.verbose:
+            lvl = log.level
+            log.setLevel(logging.INFO)
+            log.info(f'End of {self.name}: {self[self.NAME_CKPT_END].get_end()}. Duration: {self.duration(return_type="str")}')
+            log.setLevel(lvl)
+
+    def checkpoint(self, name, value=None, log_every_x=1):
+        if name not in self:
+            self[name] = Checkpoint(name, fmt=self.fmt, log_every_x=log_every_x)
+        else:
+            self[name].log_time()
+
+    def duration(self, keys=None, return_type="seconds"):
+        if keys is None:
+            keys = (self.NAME_CKPT_START, self.NAME_CKPT_END)
+        try:
+            duration = self[keys[1]].get_end() - self[keys[0]].get_start()
+            if return_type == "seconds":
+                return duration.total_seconds()
+            elif return_type == "time_delta":
+                return duration
+            elif return_type == "str":
+                return str(duration)
+            else:
+                raise ValueError(f'return_type={return_type} not understood.')
+        except KeyError as ke:
+            log.error(f"Could not find key in timer: {ke}. Available keys: {self.keys()}")
+
+    def save(self, data_object, group_name=None):
+        '''
+        Saves metadata on the MC (such as timings)
+        '''
+        if group_name is None:
+            group_name = self.name
+        set_grp = data_object.create_group(group_name)
+        d = {k: repr(v) for k, v in self.items()}
+        write_dict_to_hdf5(d, entry_point=set_grp,
+                               overwrite=False)
+
+class Checkpoint(list):
+    def __init__(self, name, checkpoints=(), log_every_x=1, fmt="%Y-%m-%d %H:%M:%S.%f",
+                 min_timedelta=0, verbose=False):
+        super().__init__()
+        self.extend(checkpoints)
+        self.name = name
+        self.fmt = fmt
+        self.log_every_x = log_every_x
+        self.counter = 0
+        self.min_timedelta = min_timedelta
+        self.log_time()
+        self.verbose = verbose
+
+    def get_start(self):
+        return self[0]
+
+    def get_end(self):
+        return self[-1]
+
+    def active(self):
+        if len(self) > 0 and \
+                (dt.datetime.now() - self[-1]).total_seconds() < self.min_timedelta:
+            #             (dt.datetime.now() - dt.datetime.strptime(self[-1], self.fmt)).total_seconds() < self.min_timedelta:
+
+            return False
+        else:
+            return True
+
+    def log_time(self, value=None):
+        if self.active():
+            if self.counter % self.log_every_x == 0:
+                if value is None:
+                    value = dt.datetime.now()  # .strftime(self.fmt)
+                self.counter += 1
+                self.append(value)
+
+    def duration(self, ref=None, return_type="seconds"):
+        if ref is None:
+            ref = self[0]
+        duration = self[-1] - ref
+        if return_type == "seconds":
+            return duration.total_seconds()
+        elif return_type == "time_delta":
+            return duration
+        elif return_type == "str":
+            return str(duration)
+        else:
+            raise ValueError(f'return_type={return_type} not understood.')
+
+    #     def __enter__(self):
+    #         if self.verbose:
+    #             lvl = log.level
+    #             log.setLevel(logging.INFO)
+    #             log.info(f'Start of checkpoint {self.name}: {self[0]}.')
+    #             log.setLevel(lvl)
+    # #         self.log_time()
+    #         return self
+
+    #     def __exit__(self, exc_type, exc_val, exc_tb):
+    #         self.log_time()
+
+    #         if self.verbose:
+    #             lvl = log.level
+    #             log.setLevel(logging.INFO)
+    #             log.info(f'End of checkpoint {self.name}: {self[-1]}. Duration: {self.duration(return_type="str")}')
+    #             log.setLevel(lvl)
+
+    def __str__(self):
+        return "['" + "', '".join(dt.datetime.strftime(pt, self.fmt) for pt in self) + "']"
+
+    def __repr__(self):
+        return self.__str__()

--- a/pycqed/utilities/timer.py
+++ b/pycqed/utilities/timer.py
@@ -2,12 +2,15 @@ import numpy as np
 import datetime as dt
 import logging
 from collections import OrderedDict
-
+from matplotlib.transforms import blended_transform_factory
 from pycqed.measurement.hdf5_data import write_dict_to_hdf5
+import matplotlib.pyplot as plt
+from pycqed.analysis_v3 import plot_mod
+import matplotlib.dates as mdates
+import functools
 
 log = logging.getLogger(__name__)
 
-import functools
 
 
 class Timer(OrderedDict):
@@ -124,11 +127,13 @@ class Timer(OrderedDict):
                 matches.append(s)
         return matches
 
-    def find_earliest(self, after=None):
+    def find_earliest(self, after=None, checkpoints="all"):
+        if checkpoints == "all":
+            checkpoints = list(self)
         if after is None:
             after = dt.datetime(1900, 1, 1)
         earliest_val = ()
-        for i, ckpt_name in enumerate(self):
+        for i, ckpt_name in enumerate(checkpoints):
             earliest_val_ckpt = self[ckpt_name].get("earliest")
             if len(earliest_val_ckpt):
                 if after < earliest_val_ckpt[1] and len(earliest_val) == 0:
@@ -162,6 +167,315 @@ class Timer(OrderedDict):
         d = {k: repr(v) for k, v in self.items()}
         write_dict_to_hdf5(d, entry_point=set_grp,
                                overwrite=False)
+
+    def sort(self, sortby="earliest", reverse=False, checkpoints="all"):
+        """
+        Returns a sorted list of checkpoint names.
+        Args:
+            sortby (str): which element to retrieve from each checkpoint,
+                passed to "which" in Checkpoint.get().
+            reverse (bool): If False, sorts list in by increasing start time if True,
+                sorts checkpoint list by decreasing start time end time.
+        Returns:
+
+        """
+        times = {}
+        if checkpoints == "all":
+            checkpoints = list(self)
+        else:
+            for ckpt in checkpoints:
+                assert ckpt in self, f"Checkpoint: {ckpt} not found in {self}"
+        for ckpt in checkpoints:
+            times[ckpt] = self[ckpt].get(sortby)[1]
+        arg_sorted = sorted(range(len(list(times.values()))),
+                            key=list(times.values()).__getitem__)
+        return np.array(list(times))[arg_sorted[::-1] if reverse else arg_sorted]
+
+    def find_start_end(self, ckpt_name, start_suffix=None,
+                       end_suffix=None, assert_single_match=True):
+        if start_suffix is None:
+            start_suffix = self.name_separator + self.NAME_CKPT_START
+        if end_suffix is None:
+            end_suffix = self.name_separator + self.NAME_CKPT_END
+        start = self.find_keys(ckpt_name + start_suffix, mode="exact")
+        end = self.find_keys(ckpt_name + end_suffix, mode="exact")
+        if assert_single_match:
+            assert len(start) == 1, \
+                f"Could not find unique start checkpoint name for " \
+                f"{ckpt_name + self.name_separator + self.NAME_CKPT_START}: {start}"
+            assert len(end) == 1, \
+                f"Could not find unique end checkpoint name for " \
+                f"{ckpt_name + self.name_separator + self.NAME_CKPT_END}: {end}"
+            return (start[0], end[0])
+
+        return (start, end)
+
+    def get_ckpt_fragments(self, checkpoints="all"):
+        """
+        Combines checkpoints to extract fragments of timers and returns
+        a dict of starting checkpoints and their duration. It tries to pair
+        up checkpoints with same name but ending in ".start" and ".end".
+        If it does find a pair, then the key in the return dict is the name
+        of the start checkpoint without ".start", and the value is a list
+        of tuples of the form (start_date0, duration0).
+        If a checkpoint has an arbitrary name, then it is paired with itself
+        and therefore the durations for each fragment will always be 0, but
+        the starting time is still usefull to know when the checkpoint was
+        triggered (possibly several times).
+        Examples:
+            >>> tm = Timer("mytimer", auto_start=False)
+            >>> for _ in range(2):
+            >>>     tm.checkpoint('mytimer.sleep.start')
+            >>>     time.sleep(1)
+            >>>     tm.checkpoint('mytimer.sleep.end')
+            >>>     # unpaired checkpoint example:
+            >>>     tm.checkpoint('mytimer.end_of_loop')
+            >>> tm.get_ckpt_fragments()
+            >>> {'mytimer.end_of_loop': [
+            >>>     (dt.datetime(2021, 2, 2, 10, 1, 16, 178730), dt.timedelta(0)),
+            >>>     (dt.datetime(2021, 2, 2, 10, 1, 17, 186281), dt.timedelta(0))],
+            >>>  'mytimer.sleep': [
+            >>>    (dt.datetime(2021, 2, 2, 10, 1, 15, 173375),
+            >>>         dt.timedelta(0, 1, 5355)),
+            >>>    (dt.datetime(2021, 2, 2, 10, 1, 16, 178730),
+            >>>         dt.timedelta(0, 1, 7551))]}
+
+        Args:
+            checkpoints:
+
+        Returns:
+
+        """
+        if checkpoints == "all":
+            end_ckpts = self.find_keys(self.name_separator +
+                                       self.NAME_CKPT_END,
+                                         mode="endswith")
+            ckpts = [ckpt for ckpt in self if ckpt not in end_ckpts]
+            ckpts = self.sort(checkpoints=ckpts)
+        elif np.ndim(checkpoints):
+            ckpts = []
+            for ckpt in checkpoints:
+                ckpt_start = self.find_keys(ckpt + self.name_separator +
+                                            self.NAME_CKPT_START,
+                               mode="contains")
+                ckpts.extend(ckpt_start)
+        else:
+            raise NotImplementedError(f"checkpoint mode : {checkpoints} not "
+                                 f"implemented")
+        ckpt_pairs = []
+        for ckpt in ckpts:
+            if ckpt.endswith(self.name_separator + self.NAME_CKPT_START):
+                ckpt = ckpt[:-len(
+                self.name_separator + self.NAME_CKPT_START)]
+                ckpt_pairs.append(self.find_start_end(ckpt))
+            elif ckpt.endswith(self.name_separator + self.NAME_CKPT_END):
+                ckpt = ckpt[:-len(
+                    self.name_separator + self.NAME_CKPT_END)]
+                ckpt_pairs.append(self.find_start_end(ckpt))
+            else:
+                # checkpoint not part of "start" or "end" binome,
+                # will return twice same checkpoint in pair
+                ckpt_pairs.append(self.find_start_end(ckpt,
+                                                      start_suffix="",
+                                                      end_suffix=""))
+
+        all_start_and_durations = {}
+        for i, (s, e) in enumerate(ckpt_pairs):
+            start_and_durations = []
+            for s_value, e_value in zip(self[s], self[e]):
+                if e_value < s_value:
+                    log.warning(
+                        f'Checkpoint {s}: End time: {e_value} occurs before start'
+                        f' time: {s_value}. Skipping.')
+                    continue
+                start_and_durations.append((s_value, e_value - s_value))
+            if s.endswith(self.name_separator + self.NAME_CKPT_START):
+                s = s[:-len(self.name_separator + self.NAME_CKPT_START)]
+            all_start_and_durations[s] = start_and_durations
+
+        return all_start_and_durations
+
+    def plot(self, checkpoints="all", type="bar", fig=None, ax=None, bar_width=0.45,
+             xunit='min', xlim=None, date_format=None, annotate=True, title=None,
+             time_axis=False, alpha=None, show_sum="absolute", ax_kwargs=None,
+             tight_layout=True):
+        """
+        Plots a timer as a timeline or broken horizontal bar chart.
+        Args:
+            checkpoints:
+            type (str): "bar" or "timeline". "bar" produces a broken horizontal
+                bar plot where each checkpoint is on a separate row. "timeline"
+                produces a single line timeline where checkpoints are of
+                different colors.
+            fig (Figure):
+            ax (Axis):
+            bar_width (float):
+            xunit (string): unit for x axis; ['us', 'ms', 's', 'min', 'h',
+                'day', 'week']
+            xlim (tuple): convenience argument for the x axis, in unit of xunit
+            date_format:
+            annotate (bool):
+            title (str):
+            time_axis (bool): whether or not to include an additional x axis to
+                display the dates.
+            alpha:
+            show_sum (str): "absolute", "relative" or None. If "absolute",
+                shows the cumulative time for each checkpoint in absolute time,
+                "relative" shows it in relative time of the first and last
+                checkpoint in the timer.
+            ax_kwargs (dict): additional kwargs for the axes properties (
+                overwrite labels, scales, etc.).
+            tight_layout (bool):
+
+        Returns:
+
+        """
+        unit_to_t_factor = dict(us=1e-6, ms=1e-3, s=1, min=60, h=3600,
+                                day=3600 * 24, week=3600 * 24 * 7)
+        all_start_and_durations = self.get_ckpt_fragments(checkpoints)
+        total_durations = {ckpt_name: np.sum([t[1] for t in times])
+                           for ckpt_name, times in all_start_and_durations.items()}
+
+        total_durations_rel = {n: v.total_seconds() / self.duration() if
+                               self.duration() != 0 else 1 for n, v in
+                               total_durations.items() }
+
+        # plotting
+        if ax_kwargs is None:
+            ax_kwargs = dict()
+        if ax is None and fig is None:
+            fig, ax = plt.subplots(figsize=(plot_mod.FIGURE_WIDTH_2COL, 2.104))
+        if fig is None:
+            fig = ax.get_figure()
+        y_ticklabels = []
+        ref_time = self.find_earliest()[-1]
+        t_factor = unit_to_t_factor.get(xunit, xunit)
+        for i, (label, values) in enumerate(all_start_and_durations.items()):
+            i = -i  # such that the labels appear in the order specified by
+                    # all_start_and_duration from top to bottom, which is the most i
+                    # intuitive ordering if a specific order is provided.
+            values = [((v[0] - ref_time).total_seconds() / t_factor,
+                       v[1].total_seconds() / t_factor) for v in values]
+
+            if type == "bar":
+                ax.broken_barh(values, ((i - bar_width), bar_width * 2), color="C2",
+                               label=label, alpha=alpha, edgecolor="C2",
+                               linewidth=0.1)
+                tform = blended_transform_factory(ax.transAxes, ax.transData)
+                if show_sum == "relative":
+                    ax.annotate(f"{total_durations_rel[label] * 100:05.2f} %",
+                                (1.01, i), xycoords=tform)
+                if show_sum == "absolute":
+                    ax.annotate(f"{self._human_delta(total_durations[label])} ",
+                                (1.01, i), xycoords=tform)
+                y_ticklabels.append(label)
+
+            elif type == "timeline":
+                if alpha is None:
+                    alpha = 0.1
+                l = " " + label.split(self.name_separator)[-1]
+                [ax.plot([v[0], v[0]], [0, 1], label=l if v == values[0] else None,
+                         color=f"C{np.abs(i)}") for v in values]
+
+                [ax.fill_betweenx([0,1], v[0], v[0] + v[1], alpha=0.1,
+                                  edgecolor=None,
+                                  color=f"C{np.abs(i)}") for v in values]
+                [ax.plot([v[0] + v[1]]*2, [0, 1], color=f"C{np.abs(i)}") for v in values]
+
+        if time_axis:
+            xmin, xmax = ax.get_xlim() if xlim is None else xlim
+            ax_time = ax.twiny()
+            ax_time.set_xlim(ref_time + dt.timedelta(seconds=xmin * t_factor),
+                             ref_time + dt.timedelta(seconds=xmax * t_factor), )
+            ax_time.set_xlabel("Time, $t$")
+            if date_format is not None:
+                ax_time.set_major_formatter(mdates.DateFormatter(date_format))
+            fig.autofmt_xdate(ha="left")
+
+        if annotate:
+            if type == "bar":
+                ax.set_yticks(-np.arange(len(all_start_and_durations)))
+                ax.set_yticklabels(y_ticklabels)
+            else:
+                ax.legend(frameon=False, fontsize="x-small")
+        if title is None:
+            title = self.name
+        ax.set_title(title)
+        ax.set_xlabel(f"Duration, $d$ ({xunit})")
+
+        if xlim is not None:
+            ax_kwargs.update(dict(xlim=xlim))
+        ax.set(**ax_kwargs)
+
+        if tight_layout:
+            fig.tight_layout()
+        return fig
+
+    def table(self, checkpoints="all"):
+        """
+        Table representation of the duration stored in a timer.
+        Args:
+            checkpoints:
+
+        Returns:
+
+        """
+        import pandas as pd
+        all_start_and_durations = self.get_ckpt_fragments(checkpoints)
+
+        total_durations = {ckpt_name: np.sum([t[1] for t in times]) for ckpt_name, times
+                           in
+                           all_start_and_durations.items()}
+        total_durations_rel = {n: v.total_seconds() / self.duration() for n, v in
+                               total_durations.items()}
+        df = pd.DataFrame([total_durations, total_durations_rel])
+        df = df.T
+        df.columns = ['Absolute cumulated time', "Relative time"]
+        return df
+
+    @staticmethod
+    def _human_delta(tdelta):
+        """
+        Takes a timedelta object and formats it for humans.
+        Usage:
+            # 149 day(s) 8 hr(s) 36 min 19 sec
+            print human_delta(datetime(2014, 3, 30) - datetime.now())
+        Example Results:
+            23 sec
+            12 min 45 sec
+            1 hr(s) 11 min 2 sec
+            3 day(s) 13 hr(s) 56 min 34 sec
+        :param tdelta: The timedelta object.
+        :return: The human formatted timedelta
+        """
+        d = dict(days=tdelta.days)
+        d['hrs'], rem = divmod(tdelta.seconds, 3600)
+        d['min'], d['sec'] = divmod(rem, 60)
+
+        if d['days'] != 0:
+            fmt = '{days} day(s) {hrs:02}:{min:02}:{sec:02}'
+        else:
+            fmt = '{hrs:02}:{min:02}:{sec:02}'
+        return fmt.format(**d)
+
+
+def multi_plot(timers, **plot_kwargs):
+    """
+    Plots several timers in a single plot. Combines the checkpoints of different
+    timers into a single timer
+    Args:
+        timers (list):
+        **plot_kwargs:
+
+    Returns:
+
+    """
+    # create dummy timer that contains checkpoints of other timers
+    # note: this won't work if several timers have the same checkpoint names
+    tm = Timer(auto_start=False)
+    [tm.update(t) for t in timers]
+    return tm.plot(**plot_kwargs)
+
 
 class Checkpoint(list):
     def __init__(self, name, values=(), log_every_x=1, fmt="%Y-%m-%d %H:%M:%S.%f",

--- a/pycqed/utilities/timer.py
+++ b/pycqed/utilities/timer.py
@@ -299,7 +299,7 @@ class Timer(OrderedDict):
     def plot(self, checkpoints="all", type="bar", fig=None, ax=None, bar_width=0.45,
              xunit='min', xlim=None, date_format=None, annotate=True, title=None,
              time_axis=False, alpha=None, show_sum="absolute", ax_kwargs=None,
-             tight_layout=True):
+             tight_layout=True, milliseconds=False):
         """
         Plots a timer as a timeline or broken horizontal bar chart.
         Args:
@@ -327,6 +327,8 @@ class Timer(OrderedDict):
             ax_kwargs (dict): additional kwargs for the axes properties (
                 overwrite labels, scales, etc.).
             tight_layout (bool):
+            milliseconds (bool): whether or not to include milliseconds in
+                displayed total durations.
 
         Returns:
 
@@ -368,8 +370,10 @@ class Timer(OrderedDict):
                     ax.annotate(f"{total_durations_rel[label] * 100:05.2f} %",
                                 (1.01, i), xycoords=tform)
                 if show_sum == "absolute":
-                    ax.annotate(f"{self._human_delta(total_durations[label])} ",
-                                (1.01, i), xycoords=tform)
+                    ax.annotate(
+                        self._human_delta(total_durations[label],
+                                          milliseconds=milliseconds) + " ",
+                        (1.01, i), xycoords=tform)
                 y_ticklabels.append(label)
 
             elif type == "timeline":
@@ -436,7 +440,7 @@ class Timer(OrderedDict):
         return df
 
     @staticmethod
-    def _human_delta(tdelta):
+    def _human_delta(tdelta, milliseconds=False):
         """
         Takes a timedelta object and formats it for humans.
         Usage:
@@ -453,12 +457,17 @@ class Timer(OrderedDict):
         d = dict(days=tdelta.days)
         d['hrs'], rem = divmod(tdelta.seconds, 3600)
         d['min'], d['sec'] = divmod(rem, 60)
-        d['sec'] += int(np.round(tdelta.microseconds * 1e-6))
+        if milliseconds:
+            d['msecs'] = int(np.round(tdelta.microseconds * 1e-3))
+        else:
+            d['sec'] += int(np.round(tdelta.microseconds * 1e-6))
 
         if d['days'] != 0:
             fmt = '{days} day(s) {hrs:02}:{min:02}:{sec:02}'
         else:
             fmt = '{hrs:02}:{min:02}:{sec:02}'
+        if milliseconds:
+            fmt += '.{msecs:03}'
         return fmt.format(**d)
 
 

--- a/pycqed/utilities/timer.py
+++ b/pycqed/utilities/timer.py
@@ -86,6 +86,8 @@ class Timer(OrderedDict):
     def checkpoint(self, name, values=(), log_every_x=1, log_init=True):
         if name not in self:
             self[name] = Checkpoint(name, values=values, fmt=self.fmt, log_every_x=log_every_x, log_init=log_init)
+        elif len(values) != 0:
+            self[name].extend(values)
         else:
             self[name].log_time()
 

--- a/pycqed/utilities/timer.py
+++ b/pycqed/utilities/timer.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 from matplotlib.transforms import blended_transform_factory
 from pycqed.measurement.hdf5_data import write_dict_to_hdf5
 import matplotlib.pyplot as plt
-from pycqed.analysis_v3 import plot_mod
 import matplotlib.dates as mdates
 import functools
 
@@ -330,6 +329,7 @@ class Timer(OrderedDict):
         Returns:
 
         """
+        from pycqed.analysis_v3 import plotting as plot_mod
         unit_to_t_factor = dict(us=1e-6, ms=1e-3, s=1, min=60, h=3600,
                                 day=3600 * 24, week=3600 * 24 * 7)
         all_start_and_durations = self.get_ckpt_fragments(checkpoints)

--- a/pycqed/utilities/timer.py
+++ b/pycqed/utilities/timer.py
@@ -16,19 +16,33 @@ class Timer(OrderedDict):
     NAME_CKPT_END = "end"
 
     def __init__(self, name="timer", fmt="%Y-%m-%d %H:%M:%S.%f", name_separator=".",
-                 verbose=False, auto_start=True, timer=None):
+                 verbose=False, auto_start=True, **kwargs):
         self.fmt = fmt
         self.name = name
         self.name_separator = name_separator
         self.verbose = verbose
-        if timer is not None:
-            super().__init__(timer)
-        if auto_start and timer is not None:
+        # timer should not start logging when initializing with previous values
+        if len(kwargs):
+            auto_start = False
+
+        # initialize previous checkpoints
+        for ckpt_name, values in kwargs.items():
+            if isinstance(values, str):
+                values = eval(values)
+            try:
+                self.checkpoint(ckpt_name, values=values, log_init=False)
+            except Exception as e:
+                log.warning(f'Could not initialize checkpoint {ckpt_name}. Skipping.')
+        if auto_start:
             self.checkpoint(self.NAME_CKPT_START)
 
     @staticmethod
-    def from_string(timer):
-        pass
+    def from_dict(timer_dict, **kwargs):
+        kwargs.update(dict(auto_start=False))
+        tm = Timer(**kwargs)
+        for ckpt_name, values in timer_dict.items():
+            tm.checkpoint(ckpt_name, values=values, log_init=False)
+        return tm
 
     def __call__(self, func):
 
@@ -67,17 +81,17 @@ class Timer(OrderedDict):
             log.info(f'End of {self.name}: {self[self.NAME_CKPT_END].get_end()}. Duration: {self.duration(return_type="str")}')
             log.setLevel(lvl)
 
-    def checkpoint(self, name, value=None, log_every_x=1):
+    def checkpoint(self, name, values=(), log_every_x=1, log_init=True):
         if name not in self:
-            self[name] = Checkpoint(name, fmt=self.fmt, log_every_x=log_every_x)
+            self[name] = Checkpoint(name, values=values, fmt=self.fmt, log_every_x=log_every_x, log_init=log_init)
         else:
             self[name].log_time()
 
     def duration(self, keys=None, return_type="seconds"):
         if keys is None:
-            keys = (self.NAME_CKPT_START, self.NAME_CKPT_END)
+            keys = (self.find_earliest()[0], self.find_latest()[0])
         try:
-            duration = self[keys[1]].get_end() - self[keys[0]].get_start()
+            duration = self[keys[1]].get("latest")[1] - self[keys[0]].get("earliest")[1]
             if return_type == "seconds":
                 return duration.total_seconds()
             elif return_type == "time_delta":
@@ -88,6 +102,55 @@ class Timer(OrderedDict):
                 raise ValueError(f'return_type={return_type} not understood.')
         except KeyError as ke:
             log.error(f"Could not find key in timer: {ke}. Available keys: {self.keys()}")
+
+    def find_keys(self, query="", mode='endswith'):
+        """
+        Finds keys of checkpoints based on query. Defaults to returning all keys.
+        Args:
+            query (str): string to search
+            mode (str): 'exact', 'contains', 'startswith', 'endswith'.
+                Decides which string matching function to use.
+
+        Returns:
+            matching_keys (list)
+        """
+        assert mode in ('exact', 'contains', 'startswith', 'endswith'), \
+            f"Unknown mode: {mode}"
+        matches = []
+        for s in self:
+            match_func = dict(exact=s.__eq__, contains=s.__contains__,
+                              startswith=s.startswith, endswith=s.endswith)
+            if match_func[mode](query):
+                matches.append(s)
+        return matches
+
+    def find_earliest(self, after=None):
+        if after is None:
+            after = dt.datetime(1900, 1, 1)
+        earliest_val = ()
+        for i, ckpt_name in enumerate(self):
+            earliest_val_ckpt = self[ckpt_name].get("earliest")
+            if len(earliest_val_ckpt):
+                if after < earliest_val_ckpt[1] and len(earliest_val) == 0:
+                    #initialize earliest value with encountered first value after "after"
+                    earliest_val = (ckpt_name,) + earliest_val_ckpt
+                if after < earliest_val_ckpt[1] < earliest_val[2]:
+                    earliest_val = (ckpt_name,) + earliest_val_ckpt
+        return earliest_val
+
+    def find_latest(self, before=None):
+        if before is None:
+            before = dt.datetime(9999, 1, 1) # in case our code is still used in the year 9998.
+        latest_val = ()
+        for i, ckpt_name in enumerate(self):
+            latest_val_ckpt = self[ckpt_name].get("latest") # (index in ckpt, value)
+            if len(latest_val_ckpt):
+                if before > latest_val_ckpt[1] and len(latest_val) == 0:
+                    #initialize earliest value with encountered first value after "after"
+                    latest_val = (ckpt_name,) + latest_val_ckpt
+                if before > latest_val_ckpt[1] > latest_val[2]:
+                    latest_val = (ckpt_name,) + latest_val_ckpt
+        return latest_val
 
     def save(self, data_object, group_name=None):
         '''
@@ -101,23 +164,55 @@ class Timer(OrderedDict):
                                overwrite=False)
 
 class Checkpoint(list):
-    def __init__(self, name, checkpoints=(), log_every_x=1, fmt="%Y-%m-%d %H:%M:%S.%f",
-                 min_timedelta=0, verbose=False):
+    def __init__(self, name, values=(), log_every_x=1, fmt="%Y-%m-%d %H:%M:%S.%f",
+                 min_timedelta=0, verbose=False, log_init=True):
         super().__init__()
-        self.extend(checkpoints)
         self.name = name
         self.fmt = fmt
         self.log_every_x = log_every_x
         self.counter = 0
         self.min_timedelta = min_timedelta
-        self.log_time()
         self.verbose = verbose
+
+        for v in values:
+            if isinstance(v, str):
+                v = dt.datetime.strptime(v, self.fmt)
+            self.append(v)
+        if log_init:
+            self.log_time()
 
     def get_start(self):
         return self[0]
 
     def get_end(self):
         return self[-1]
+
+    def get(self, which="latest"):
+        """
+        Convenience function to get lastest, earliest of nth checkpoint value (and index).
+        Returns empty tuple if self is empty.
+        Args:
+            which (str or int): "earliest" returns value with earliest datetime,
+                "latest" with the latest datetime, and integer n returns the nth datetime value
+                 (starting from earliest)
+
+        Returns:
+            (index, datetime_value)
+
+        """
+        if which == "latest":
+            which_ind = -1
+        elif which == "earliest":
+            which_ind = 0
+        elif isinstance(which, int):
+            which_ind = which
+        else:
+            raise ValueError(f'which not in ("latest", "earliest", integer): {which}')
+        argsorted = np.argsort(self)[::-1] # from recent to latest
+        if len(argsorted):
+            return argsorted[which_ind], self[which_ind]
+        else:
+            return ()
 
     def active(self):
         if len(self) > 0 and \

--- a/pycqed/utilities/timer.py
+++ b/pycqed/utilities/timer.py
@@ -451,6 +451,7 @@ class Timer(OrderedDict):
         d = dict(days=tdelta.days)
         d['hrs'], rem = divmod(tdelta.seconds, 3600)
         d['min'], d['sec'] = divmod(rem, 60)
+        d['sec'] += int(np.round(tdelta.microseconds * 1e-6))
 
         if d['days'] != 0:
             fmt = '{days} day(s) {hrs:02}:{min:02}:{sec:02}'


### PR DESCRIPTION
This PR adds the Timer framework and adds timers to some of the core modules (e.g., MC, detector_functions, QuantumExperiment, ...) and to some of the experiments.

Tested on S17 & on virtual setups.

@nathlacroix Thanks for the work that you invested in this and for the nicely documented code. I have looked at your code and approve it, so your job as a reviewer would only be to check my additions and to check the PR as a whole (e.g., whether you think something is missing). We both know that there are still aspects that we want to improve in the future, but we should still merge this part now since 1) it is useful already and 2) it has the potential to cause many merge conflicts in the future if we do not merge it soon.

FYI @antsr @stephlazar 
