### PR TITLE
Pulses with mirror pattern

### DIFF
--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -801,8 +801,8 @@ class BufferedFLIPPulse(pulse.Pulse):
             'channel2': None,
             'amplitude': 0,
             'amplitude2': 0,
-            'mirror_pattern': None,
-            'mirror_correction': None,
+            'mirror_pattern': None,  # see Segment.resolve_mirror
+            'mirror_correction': None,  # see Segment.resolve_mirror
             'pulse_length': 0,
             'buffer_length_start': 30e-9,
             'buffer_length_end': 30e-9,

--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -760,7 +760,7 @@ class BufferedFLIPPulse(pulse.Pulse):
         self.channel2 = channel2
         self.channels = [self.channel, self.channel2]
 
-        self.amps = {channel: self.amplitude, channel2: self.amplitude2}
+        self._update_amplitudes()
 
         delay = self.channel_relative_delay  # delay of pulse on channel2 wrt pulse on channel
         bls = self.buffer_length_start  # initial value for buffer length start passed with kw
@@ -801,6 +801,8 @@ class BufferedFLIPPulse(pulse.Pulse):
             'channel2': None,
             'amplitude': 0,
             'amplitude2': 0,
+            'mirror_pattern': None,
+            'mirror_correction': None,
             'pulse_length': 0,
             'buffer_length_start': 30e-9,
             'buffer_length_end': 30e-9,
@@ -811,8 +813,12 @@ class BufferedFLIPPulse(pulse.Pulse):
         }
         return params
 
-    def chan_wf(self, chan, tvals):
+    def _update_amplitudes(self):
+        self.amps = {self.channel: self.amplitude,
+                     self.channel2: self.amplitude2}
 
+    def chan_wf(self, chan, tvals):
+        self._update_amplitudes()
         amp = self.amps[chan]
         buffer_start = self.buffer_length_start[chan]
         l1 = self.length1[chan]
@@ -835,6 +841,7 @@ class BufferedFLIPPulse(pulse.Pulse):
         hashlist = self.common_hashables(tstart, channel)
         if channel not in self.channels or self.pulse_off:
             return hashlist
+        self._update_amplitudes()
         amp = self.amps[channel]
         buffer_start = self.buffer_length_start[channel]
         buffer_end = self.buffer_length_end[channel]

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -163,7 +163,14 @@ class Segment:
                 p1.basis_rotation = {}
                 p1.delay = 0
                 p1.pulse_obj.name += '_ese'
-                self.resolved_pulses.append(p1)
+                p1.is_ese_copy = True
+                if p1.pulse_obj.codeword == "no_codeword":
+                   self.resolved_pulses.append(p1)
+                else:
+                    ese_chs = [ch for m, ch in zip(ch_mask, p.pulse_obj.channels) if m]
+                    log.warning('enforce_single_element cannot use codewords, '
+                                f'ignoring {p.pulse_obj.name} on channels '
+                                f'{", ".join(ese_chs)}')
             else:
                 p = deepcopy(p)
                 self.resolved_pulses.append(p)
@@ -735,9 +742,10 @@ class Segment:
         """
         op_counts = {}
         for p in self.resolved_pulses:
-            if p.op_code not in op_counts:
-                op_counts[p.op_code] = 0
-            op_counts[p.op_code] += 1
+            pulse_category = (p.op_code, getattr(p, "is_ese_copy", False))
+            if pulse_category not in op_counts:
+                op_counts[pulse_category] = 0
+            op_counts[pulse_category] += 1
             pattern = getattr(p.pulse_obj, 'mirror_pattern', None)
             if pattern is None or pattern == 'none':
                 continue
@@ -745,9 +753,9 @@ class Segment:
                 if pattern == pa1:
                     pattern = pa2
             pattern = deepcopy(pattern)
-            while len(pattern) < op_counts[p.op_code]:
+            while len(pattern) < op_counts[pulse_category]:
                 pattern += pattern
-            if not pattern[op_counts[p.op_code] - 1]:
+            if not pattern[op_counts[pulse_category] - 1]:
                 continue
             # use mirror pulse
             mirror_correction = getattr(p.pulse_obj, 'mirror_correction', None)


### PR DESCRIPTION
This PR adds the possibility to specify a mirror_pattern in a pulse, which defines whether and how to mirror the amplitude of the pulse when the pulse is used repeatedly. This can be used to implement toggling unipolar CZ gates.

Inviting @nathlacroix to review.
FYI @stephlazar @antsr 