### PR TITLE
Improvements ins Flux Pulse Scope Measurement and Analysis

### DIFF
--- a/pycqed/analysis/fitting_models.py
+++ b/pycqed/analysis/fitting_models.py
@@ -1231,7 +1231,16 @@ def sum_int(x,y):
     return np.cumsum(y[:-1]*(x[1:]-x[:-1]))
 
 
-def Gaussian(freq,sigma,mu,ampl,offset):
+def DoubleGaussian(freq, sigma, mu, ampl, sigma0, mu0, ampl0, offset):
+    '''
+    Double Gaussian function
+    '''
+    return ampl/(sigma*np.sqrt(2*np.pi))*np.exp(-0.5*((freq - mu)/sigma)**2) + \
+           ampl0/(sigma0*np.sqrt(2*np.pi))*np.exp(-0.5*((freq - mu0)/sigma0)**2) + \
+           offset
+
+
+def Gaussian(freq, sigma, mu, ampl, offset):
     '''
     Gaussian function
     '''

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -999,7 +999,8 @@ class BaseDataAnalysis(object):
         for key in key_list:
             # go over all the plot_dicts
             pdict = self.plot_dicts[key]
-            pdict['no_label'] = no_label
+            if 'no_label' not in pdict:
+                pdict['no_label'] = no_label
             # Use the key of the plot_dict if no ax_id is specified
             pdict['fig_id'] = pdict.get('fig_id', key)
             pdict['ax_id'] = pdict.get('ax_id', None)
@@ -1585,6 +1586,7 @@ class BaseDataAnalysis(object):
         plot_ytick_loc = pdict.get('ytick_loc', None)
         plot_transpose = pdict.get('transpose', False)
         plot_nolabel = pdict.get('no_label', False)
+        plot_nolabel_units = pdict.get('no_label_units', False)
         plot_normalize = pdict.get('normalize', False)
         plot_logzscale = pdict.get('logzscale', False)
         plot_logxscale = pdict.get('logxscale', False)
@@ -1646,6 +1648,11 @@ class BaseDataAnalysis(object):
                             transpose=plot_transpose,
                             normalize=plot_normalize)
 
+        if plot_logxscale:
+            axs.set_xscale('log')
+        if plot_logyscale:
+            axs.set_yscale('log')
+
         if plot_xrange is None:
             if plot_xwidth is not None:
                 xmin, xmax = min([min(xvals) - plot_xwidth[tt] / 2
@@ -1701,15 +1708,17 @@ class BaseDataAnalysis(object):
 
         if not plot_nolabel:
             self.label_color2D(pdict, axs)
+        if plot_nolabel_units:
+            axs.set_xlabel(pdict['xlabel'])
+            axs.set_ylabel(pdict['ylabel'])
 
         axs.cmap = out['cmap']
         if plot_cbar:
-            self.plot_colorbar(axs=axs, pdict=pdict)
-
-        if plot_logxscale:
-            axs.set_xscale('log')
-        if plot_logyscale:
-            axs.set_yscale('log')
+            no_label = plot_nolabel
+            if plot_nolabel and plot_nolabel_units:
+                no_label = False
+            self.plot_colorbar(axs=axs, pdict=pdict,
+                               no_label=no_label)
 
     def label_color2D(self, pdict, axs):
         plot_transpose = pdict.get('transpose', False)
@@ -1733,7 +1742,7 @@ class BaseDataAnalysis(object):
             # axs.set_title(plot_title)
 
     def plot_colorbar(self, cax=None, key=None, pdict=None, axs=None,
-                      orientation='vertical'):
+                      orientation='vertical', no_label=None):
         if key is not None:
             pdict = self.plot_dicts[key]
             axs = self.axs[key]
@@ -1743,6 +1752,9 @@ class BaseDataAnalysis(object):
                     'pdict and axs must be specified'
                     ' when no key is specified.')
         plot_nolabel = pdict.get('no_label', False)
+        if no_label is not None:
+            plot_nolabel = no_label
+
         plot_clabel = pdict.get('clabel', None)
         plot_cbarwidth = pdict.get('cbarwidth', '10%')
         plot_cbarpad = pdict.get('cbarpad', '5%')

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -1707,7 +1707,6 @@ class BaseDataAnalysis(object):
             self.plot_colorbar(axs=axs, pdict=pdict)
 
         if plot_logxscale:
-            print('here')
             axs.set_xscale('log')
         if plot_logyscale:
             axs.set_yscale('log')

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -1587,6 +1587,8 @@ class BaseDataAnalysis(object):
         plot_nolabel = pdict.get('no_label', False)
         plot_normalize = pdict.get('normalize', False)
         plot_logzscale = pdict.get('logzscale', False)
+        plot_logxscale = pdict.get('logxscale', False)
+        plot_logyscale = pdict.get('logyscale', False)
         plot_origin = pdict.get('origin', 'lower')
 
         if plot_logzscale:
@@ -1703,6 +1705,12 @@ class BaseDataAnalysis(object):
         axs.cmap = out['cmap']
         if plot_cbar:
             self.plot_colorbar(axs=axs, pdict=pdict)
+
+        if plot_logxscale:
+            print('here')
+            axs.set_xscale('log')
+        if plot_logyscale:
+            axs.set_yscale('log')
 
     def label_color2D(self, pdict, axs):
         plot_transpose = pdict.get('transpose', False)

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -8005,11 +8005,12 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                     'label', dimension=1, param_names=param_name)
                 yunit = self.sp.get_sweep_params_property(
                     'unit', dimension=1, param_names=param_name)
+                xvals = self.proc_data_dict['proc_sweep_points_dict'][qbn][
+                    'sweep_points']
                 self.plot_dicts[f'{base_plot_name}_main'] = {
                     'plotfn': self.plot_colorxy,
                     'fig_id': base_plot_name,
-                    'xvals': self.proc_data_dict['proc_sweep_points_dict'][qbn][
-                        'sweep_points'],
+                    'xvals': xvals,
                     'yvals': self.proc_data_dict['proc_sweep_points_2D_dict'][
                         qbn][param_name],
                     'zvals': self.proc_data_dict['proc_data_to_fit'][qbn],
@@ -8036,3 +8037,17 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                     'color': 'r',
                     'linestyle': '-',
                     'marker': 'x'}
+
+                # plot with log scale on x-axis
+                self.plot_dicts[f'{base_plot_name}_main_log'] = deepcopy(
+                    self.plot_dicts[f'{base_plot_name}_main'])
+                self.plot_dicts[f'{base_plot_name}_main_log']['fig_id'] = \
+                    f'{base_plot_name}_log'
+                self.plot_dicts[f'{base_plot_name}_main_log']['logxscale'] = True
+                self.plot_dicts[f'{base_plot_name}_main_log']['xrange'] = \
+                    [min(xvals), max(xvals)]
+
+                self.plot_dicts[f'{base_plot_name}_fit_log'] = deepcopy(
+                    self.plot_dicts[f'{base_plot_name}_fit'])
+                self.plot_dicts[f'{base_plot_name}_fit_log']['fig_id'] = \
+                    f'{base_plot_name}_log'

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -8089,8 +8089,6 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                     'xrange': [min(xvals*1e6), max(xvals*1e6)],
                     'no_label_units': True,
                     'no_label': True,
-                    'title': (self.raw_data_dict['timestamp'] + ' ' +
-                              self.measurement_strings[qbn]),
                     'clabel': 'Strongest principal component (arb.)' if \
                         'pca' in self.rotation_type.lower() else \
                         '{} state population'.format(
@@ -8104,6 +8102,8 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                         f'fitted_freqs_{qbn}']['val']/1e9,
                     'yerr': self.proc_data_dict['analysis_params_dict'][
                         f'fitted_freqs_{qbn}']['stderr']/1e9,
+                    'title': (self.raw_data_dict['timestamp'] + ' ' +
+                              self.measurement_strings[qbn]),
                     'color': 'r',
                     'linestyle': '-',
                     'marker': 'x'}

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -8076,15 +8076,34 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                     'marker': 'x'}
 
                 # plot with log scale on x-axis
-                self.plot_dicts[f'{base_plot_name}_main_log'] = deepcopy(
-                    self.plot_dicts[f'{base_plot_name}_main'])
-                self.plot_dicts[f'{base_plot_name}_main_log']['fig_id'] = \
-                    f'{base_plot_name}_log'
-                self.plot_dicts[f'{base_plot_name}_main_log']['logxscale'] = True
-                self.plot_dicts[f'{base_plot_name}_main_log']['xrange'] = \
-                    [min(xvals), max(xvals)]
+                self.plot_dicts[f'{base_plot_name}_main_log'] = {
+                    'plotfn': self.plot_colorxy,
+                    'fig_id': f'{base_plot_name}_log',
+                    'xvals': xvals*1e6,
+                    'yvals': self.proc_data_dict['proc_sweep_points_2D_dict'][
+                        qbn][param_name]/1e9,
+                    'zvals': self.proc_data_dict['proc_data_to_fit'][qbn],
+                    'xlabel': f'{xlabel} ($\\mu${xunit})',
+                    'ylabel': f'{ylabel} (G{yunit})',
+                    'logxscale': True,
+                    'xrange': [min(xvals*1e6), max(xvals*1e6)],
+                    'no_label_units': True,
+                    'no_label': True,
+                    'title': (self.raw_data_dict['timestamp'] + ' ' +
+                              self.measurement_strings[qbn]),
+                    'clabel': 'Strongest principal component (arb.)' if \
+                        'pca' in self.rotation_type.lower() else \
+                        '{} state population'.format(
+                            self.get_latex_prob_label(self.data_to_fit[qbn]))}
 
-                self.plot_dicts[f'{base_plot_name}_fit_log'] = deepcopy(
-                    self.plot_dicts[f'{base_plot_name}_fit'])
-                self.plot_dicts[f'{base_plot_name}_fit_log']['fig_id'] = \
-                    f'{base_plot_name}_log'
+                self.plot_dicts[f'{base_plot_name}_fit_log'] = {
+                    'fig_id': f'{base_plot_name}_log',
+                    'plotfn': self.plot_line,
+                    'xvals': self.delays_for_fit[qbn]*1e6,
+                    'yvals': self.proc_data_dict['analysis_params_dict'][
+                        f'fitted_freqs_{qbn}']['val']/1e9,
+                    'yerr': self.proc_data_dict['analysis_params_dict'][
+                        f'fitted_freqs_{qbn}']['stderr']/1e9,
+                    'color': 'r',
+                    'linestyle': '-',
+                    'marker': 'x'}

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -7834,14 +7834,16 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
             self.ghost = {qbn: False for qbn in self.qb_names}
 
     def prepare_fitting_slice(self, freqs, qbn, mu_guess,
-                              slice_idx=None, data_slice=None):
+                              slice_idx=None, data_slice=None,
+                              mu0_guess=None, do_double_fit=False):
         if slice_idx is None:
             raise ValueError('"slice_idx" cannot be None. It is used '
                              'for unique names in the fit_dicts.')
         if data_slice is None:
             data_slice = self.proc_data_dict['proc_data_to_fit'][qbn][
                          :, slice_idx]
-        GaussianModel = fit_mods.GaussianModel
+        GaussianModel = lmfit.Model(fit_mods.DoubleGaussian) if do_double_fit \
+            else lmfit.Model(fit_mods.Gaussian)
         ampl_guess = (data_slice.max() - data_slice.min()) / \
                      0.4 * self.sign_of_peaks[qbn] * self.sigma_guess[qbn]
         offset_guess = data_slice[0]
@@ -7857,6 +7859,16 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
         GaussianModel.set_param_hint('offset',
                                      value=offset_guess,
                                      vary=True)
+        if do_double_fit:
+            GaussianModel.set_param_hint('sigma0',
+                                         value=self.sigma_guess[qbn],
+                                         vary=True)
+            GaussianModel.set_param_hint('mu0',
+                                         value=mu0_guess,
+                                         vary=True)
+            GaussianModel.set_param_hint('ampl0',
+                                         value=ampl_guess/2,
+                                         vary=True)
         guess_pars = GaussianModel.make_params()
         self.set_user_guess_pars(guess_pars)
 
@@ -7869,6 +7881,7 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
 
     def prepare_fitting(self):
         self.rectangles_exclude = self.get_param_value('rectangles_exclude')
+        self.delays_double_fit = self.get_param_value('delays_double_fit')
         self.delay_ranges_to_fit = self.get_param_value(
             'delay_ranges_to_fit', default_value={})
         self.freq_ranges_to_fit = self.get_param_value(
@@ -7897,6 +7910,7 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                 if first_cal_state_idxs is None:
                     first_cal_state_idxs = []
             for i, delay in enumerate(delays):
+                do_double_fit = False
                 if not fit_first_cal_state.get(qbn, True) and \
                         i-len(delays) in first_cal_state_idxs:
                     continue
@@ -7922,13 +7936,31 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
                                 freqs = freqs[reduction_arr]
                                 data_slice = data_slice[reduction_arr]
 
+                    if self.delays_double_fit is not None and \
+                            self.delays_double_fit.get(qbn, None) is not None:
+                        rectangle = self.delays_double_fit[qbn]
+                        do_double_fit = rectangle[0] < delay < rectangle[1]
+
                     self.freqs_for_fit[qbn].append(freqs)
                     self.delays_for_fit[qbn] = np.append(
                         self.delays_for_fit[qbn], delay)
-                    mu_guess = freqs[np.argmax(
-                        data_slice * self.sign_of_peaks[qbn])]
+
+                    if do_double_fit:
+                        peak_indices = sp.signal.find_peaks(
+                            data_slice, distance=50e6/(freqs[1] - freqs[0]))[0]
+                        peaks = data_slice[peak_indices]
+                        srtd_idxs = np.argsort(np.abs(peaks))
+                        mu_guess = freqs[peak_indices[srtd_idxs[-1]]]
+                        mu0_guess = freqs[peak_indices[srtd_idxs[-2]]]
+                    else:
+                        mu_guess = freqs[np.argmax(
+                            data_slice * self.sign_of_peaks[qbn])]
+                        mu0_guess = None
+
                     self.prepare_fitting_slice(freqs, qbn, mu_guess, i,
-                                               data_slice=data_slice)
+                                               data_slice=data_slice,
+                                               mu0_guess=mu0_guess,
+                                               do_double_fit=do_double_fit)
 
     def analyze_fit_results(self):
         self.proc_data_dict['analysis_params_dict'] = OrderedDict()
@@ -7941,8 +7973,13 @@ class FluxPulseScopeAnalysis(MultiQubit_TimeDomain_Analysis):
             deep = False
             for i, fk in enumerate(fit_keys):
                 fit_res = self.fit_dicts[fk]['fit_res']
-                fitted_freqs[i] = fit_res.best_values['mu']
-                fitted_freqs_errs[i] = fit_res.params['mu'].stderr
+                mu_param = 'mu'
+                if 'mu0' in fit_res.best_values:
+                    mu_param = 'mu' if fit_res.best_values['mu'] > \
+                                       fit_res.best_values['mu0'] else 'mu0'
+
+                fitted_freqs[i] = fit_res.best_values[mu_param]
+                fitted_freqs_errs[i] = fit_res.params[mu_param].stderr
                 if self.from_lower[qbn]:
                     if self.ghost[qbn]:
                         if (fitted_freqs[i - 1] - fit_res.best_values['mu']) / \

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -294,7 +294,10 @@ class FluxPulseScope(ParallelLOSweepExperiment):
         Returns: None
 
     """
-    kw_for_task_keys = ['ro_pulse_delay', 'fp_truncation', 'fp_truncation_buffer']
+    kw_for_task_keys = ['ro_pulse_delay', 'fp_truncation',
+                        'fp_truncation_buffer',
+                        'fp_compensation',
+                        'fp_compensation_amp']
     kw_for_sweep_points = {
         'freqs': dict(param_name='freq', unit='Hz',
                       label=r'drive frequency, $f_d$',
@@ -315,7 +318,8 @@ class FluxPulseScope(ParallelLOSweepExperiment):
 
     def sweep_block(self, qb, sweep_points, flux_op_code=None,
                     ro_pulse_delay=None,
-                    fp_truncation=None, fp_truncation_buffer=None, **kw):
+                    fp_truncation=False, fp_compensation=False,
+                    fp_compensation_amp=None, fp_truncation_buffer=None, **kw):
         """
         Performs X180 pulse on top of a fluxpulse
         Timings of sequence
@@ -339,22 +343,22 @@ class FluxPulseScope(ParallelLOSweepExperiment):
             flux_op_code = f'FP {qb}'
         if ro_pulse_delay is None:
             ro_pulse_delay = 100e-9
-        if fp_truncation is None:
-            fp_truncation = False
         if fp_truncation_buffer is None:
             fp_truncation_buffer = 5e-8
+        if fp_compensation_amp is None:
+            fp_compensation_amp = -2
 
         if ro_pulse_delay is 'auto' and fp_truncation is True:
             raise Exception('fp_truncation does currently not work ' + \
-                'with the auto mode of ro_pulse_delay.')
+                            'with the auto mode of ro_pulse_delay.')
 
         pulse_modifs = {'attr=name,op_code=X180': f'FPS_Pi',
                         'attr=element_name,op_code=X180': 'FPS_Pi_el'}
         b = self.block_from_ops(f'ge_flux {qb}',
                                 [f'X180 {qb}'] + [flux_op_code] * \
-                                    (2 if fp_truncation else 1),
+                                (2 if fp_compensation else 1),
                                 pulse_modifs=pulse_modifs)
-    
+
         fp = b.pulses[1]
         fp['ref_point'] = 'middle'
         bl_start = fp.get('buffer_length_start', 0)
@@ -364,28 +368,38 @@ class FluxPulseScope(ParallelLOSweepExperiment):
             'delay', func=lambda x, o=bl_start: -(x + o))
 
         if fp_truncation:
-            cp = b.pulses[2]
             original_fp_length = fp['pulse_length']
             max_fp_sweep_length = np.max(
                 sweep_points.get_sweep_params_property(
                     'values', dimension=0, param_names='delay'))
             sweep_diff = max(max_fp_sweep_length - original_fp_length, 0)
             length_function = lambda x, opl=original_fp_length, \
-                o=bl_start+fp_truncation_buffer: max(min((x + o), opl), 0) # TODO: check what happens if buffer_length_start and buffer_length_end are zero.
+                                     o=bl_start + fp_truncation_buffer: max(
+                min((x + o), opl), 0)
+            # TODO: check what happens if buffer_length_start and buffer_length_end are zero.
 
             fp['pulse_length'] = ParametricValue(
                 'delay', func=length_function)
-            cp['pulse_length'] = ro_pulse_delay - 2 * bl_start - 2 * bl_end \
-                                    - fp_truncation_buffer - sweep_diff
-            if cp['pulse_length'] <= 0:
-                raise Exception('ro_pulse_delay is too short to fit the ' + \
-                    'compensation pulse. Please choose a longer ro_pulse_delay.')
-            cp['pulse_delay'] = sweep_diff + bl_start
-            comp_amp_func = (lambda x, a=fp['amplitude'], cpl=cp['pulse_length'], \
-                                fnc=length_function: - a * fnc(x) / cpl)
-            cp['amplitude'] = ParametricValue(
-                'delay', func=comp_amp_func
-            )
+            if fp_compensation:
+                cp = b.pulses[2]
+                cp['amplitude'] = -np.sign(fp['amplitude']) * np.abs(
+                    fp_compensation_amp)
+                cp['pulse_delay'] = sweep_diff + bl_start
+                tau = 200e-9 * 100
+
+                def t_trunc(x, fnc=length_function, tau=tau,
+                            fp_amp=fp['amplitude'], cp_amp=cp['amplitude']):
+                    fp_length = fnc(x)
+
+                    def v_c(tau, fp_length, fp_amp, v_c_start=0):
+                        return fp_amp - (fp_amp - v_c_start) * np.exp(
+                            -fp_length / tau)
+
+                    v_c_fp = v_c(tau, fp_length, fp_amp, v_c_start=0)
+                    return -np.log(cp_amp / (cp_amp - v_c_fp)) * tau
+
+                cp['pulse_length'] = ParametricValue('delay', func=t_trunc)
+                # TODO: implement that the ro_delay is adjusted accordingly!
 
         if ro_pulse_delay == 'auto':
             delay = \

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -299,7 +299,8 @@ class FluxPulseScope(ParallelLOSweepExperiment):
                         'fp_compensation',
                         'fp_compensation_amp',
                         'fp_during_ro', 'tau',
-                        'fp_during_ro_length']
+                        'fp_during_ro_length',
+                        'fp_during_ro_buffer']
     kw_for_sweep_points = {
         'freqs': dict(param_name='freq', unit='Hz',
                       label=r'drive frequency, $f_d$',
@@ -323,7 +324,8 @@ class FluxPulseScope(ParallelLOSweepExperiment):
                     fp_truncation=False, fp_compensation=False,
                     fp_compensation_amp=None, fp_truncation_buffer=None,
                     fp_during_ro=False, tau=None,
-                    fp_during_ro_length=None, **kw):
+                    fp_during_ro_length=None,
+                    fp_during_ro_buffer=None, **kw):
         """
         Performs X180 pulse on top of a fluxpulse
         Timings of sequence
@@ -368,6 +370,8 @@ class FluxPulseScope(ParallelLOSweepExperiment):
             tau = 20e-6
         if fp_during_ro_length is None:
             fp_during_ro_length = 2e-6
+        if fp_during_ro_buffer is None:
+            fp_during_ro_buffer = 0.2e-6
 
         if ro_pulse_delay is 'auto' and (fp_truncation or \
             hasattr(fp_truncation, '__iter__')):
@@ -375,6 +379,8 @@ class FluxPulseScope(ParallelLOSweepExperiment):
                             'with the auto mode of ro_pulse_delay.')
 
         assert not (fp_compensation and fp_during_ro)
+
+        assert not (fp_truncation and fp_during_ro)
 
         pulse_modifs = {'attr=name,op_code=X180': f'FPS_Pi',
                         'attr=element_name,op_code=X180': 'FPS_Pi_el'}
@@ -433,29 +439,39 @@ class FluxPulseScope(ParallelLOSweepExperiment):
 
             # TODO: this feature does not work if the delay is larger
             # than the pulse length!
-            if fp_during_ro:
-                rfp = b.pulses[2]
-                rfp['pulse_delay'] = 0
-                rfp['pulse_length'] = fp_during_ro_length
+            # if fp_during_ro:
+            #     rfp = b.pulses[2]
+            #     rfp['pulse_delay'] = 0
+            #     rfp['pulse_length'] = fp_during_ro_length
 
-                def rfp_amp(x, fnc=length_function, tau=tau,
-                    fp_amp=fp['amplitude']):
-                    fp_length = fnc(x)
-                    return fp_amp * (1-np.exp(-fp_length/tau))
+            #     def rfp_amp(x, fnc=length_function, tau=tau,
+            #         fp_amp=fp['amplitude']):
+            #         fp_length = fnc(x)
+            #         return fp_amp * (1-np.exp(-fp_length/tau))
 
-                rfp['amplitude'] = ParametricValue('delay', func=rfp_amp)
+            #     rfp['amplitude'] = ParametricValue('delay', func=rfp_amp)
 
         else: #fp_truncation == False
             # TODO: this feature does not work if the delay is larger
             # than the pulse length!
             if fp_during_ro:
                 rfp = b.pulses[2]
-                rfp['pulse_delay'] = 0
-                rfp['pulse_length'] = fp_during_ro_length
 
-                fp_amp = fp['amplitude']
-                fp_length = fp['pulse_length']
-                rfp['amplitude'] = fp_amp * (1-np.exp(-fp_length/tau))
+                def length_func(x, offset=fp_during_ro_buffer):
+                    return max(x+offset, 0)
+
+                def rfp_delay(x, length_func=length_func, opl=fp['pulse_length']):
+                    return -(opl-length_func(x))
+
+                def rfp_amp(x, length_func=length_func, rfp_delay=rfp_delay,
+                    tau=tau, fp_amp=fp['amplitude']):
+                    fp_length=length_func(x)
+                    return fp_amp*(-1+np.exp(-fp_length/tau)) \
+                        * (-1 if rfp_delay(x) > 0 else 1)
+
+                rfp['pulse_length'] = fp_during_ro_length
+                rfp['pulse_delay'] = ParametricValue('delay', func=rfp_delay)
+                rfp['amplitude'] = ParametricValue('delay', func=rfp_amp)
 
         if ro_pulse_delay == 'auto':
             delay = \

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -415,7 +415,6 @@ class FluxPulseScope(ParallelLOSweepExperiment):
             fp_length_function = lambda x, opl=original_fp_length, \
                 o=bl_start + fp_truncation_buffer, trunc=fp_truncation: \
                 max(min((x + o), opl), 0) if (x>np.min(trunc) and x<np.max(trunc)) else opl
-            # TODO: check what happens if buffer_length_start and buffer_length_end are zero.
 
             fp['pulse_length'] = ParametricValue(
                 'delay', func=fp_length_function)

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -366,9 +366,10 @@ class FluxPulseScope(ParallelLOSweepExperiment):
         if fp_truncation:
             cp = b.pulses[2]
             original_fp_length = fp['pulse_length']
-            sweep_diff = np.abs(original_fp_length - \
-                            np.max( sweep_points.get_sweep_params_property(
-                                'values', dimension=0, param_names='delay')))
+            max_fp_sweep_length = np.max(
+                sweep_points.get_sweep_params_property(
+                    'values', dimension=0, param_names='delay'))
+            sweep_diff = max(max_fp_sweep_length - original_fp_length, 0)
             length_function = lambda x, opl=original_fp_length, \
                 o=bl_start+fp_truncation_buffer: max(min((x + o), opl), 0) # TODO: check what happens if buffer_length_start and buffer_length_end are zero.
 

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -348,7 +348,8 @@ class FluxPulseScope(ParallelLOSweepExperiment):
         if fp_compensation_amp is None:
             fp_compensation_amp = -2
 
-        if ro_pulse_delay is 'auto' and fp_truncation is True:
+        if ro_pulse_delay is 'auto' and (fp_truncation or \
+            hasattr(fp_truncation, '__iter__')):
             raise Exception('fp_truncation does currently not work ' + \
                             'with the auto mode of ro_pulse_delay.')
 
@@ -367,15 +368,20 @@ class FluxPulseScope(ParallelLOSweepExperiment):
         fp['pulse_delay'] = ParametricValue(
             'delay', func=lambda x, o=bl_start: -(x + o))
 
-        if fp_truncation:
+        if (fp_truncation or hasattr(fp_truncation, '__iter__')):
+            if not hasattr(fp_truncation, '__iter__'):
+                fp_truncation = [-np.inf, np.inf]
             original_fp_length = fp['pulse_length']
             max_fp_sweep_length = np.max(
                 sweep_points.get_sweep_params_property(
                     'values', dimension=0, param_names='delay'))
             sweep_diff = max(max_fp_sweep_length - original_fp_length, 0)
-            length_function = lambda x, opl=original_fp_length, \
-                                     o=bl_start + fp_truncation_buffer: max(
-                min((x + o), opl), 0)
+            def length_function(x, opl=original_fp_length, \
+                o=bl_start + fp_truncation_buffer, trunc=fp_truncation):
+                if (x>np.min(trunc) and x<np.max(trunc)):
+                    return max(min((x + o), opl), 0)
+                else:
+                    return opl
             # TODO: check what happens if buffer_length_start and buffer_length_end are zero.
 
             fp['pulse_length'] = ParametricValue(

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -339,7 +339,8 @@ class FluxPulseScope(ParallelLOSweepExperiment):
         :param flux_op_code: (optional str) the flux pulse op_code (default
             FP qb)
         :param ro_pulse_delay: Can be 'auto' to start the readout after
-            the end of the flux pulse or a delay in seconds to start a fixed
+            the end of the flux pulse (or in the middle of the readout-flux-pulse
+            if fp_during_ro is True) or a delay in seconds to start a fixed
             amount of time after the drive pulse. If not provided or set to
             None, a default fixed delay of 100e-9 is used.
         :param fp_truncation: Truncate the flux pulse after the drive pulse
@@ -478,13 +479,19 @@ class FluxPulseScope(ParallelLOSweepExperiment):
                 rfp['amplitude'] = ParametricValue('delay', func=rfp_amp)
 
         if ro_pulse_delay == 'auto':
-            delay = \
-                fp['pulse_length'] - np.min(
-                    sweep_points.get_sweep_params_property(
-                        'values', dimension=0, param_names='delay')) + \
-                fp.get('buffer_length_end', 0) + fp.get('trans_length', 0)
-            b.block_end.update({'ref_pulse': 'FPS_Pi', 'ref_point': 'middle',
-                                'pulse_delay': delay})
+            if fp_during_ro:
+                # start the ro pulse in the middle of the fp_during_ro pulse
+                delay = fp_during_ro_buffer + fp_during_ro_length/2
+                b.block_end.update({'ref_pulse': 'FPS_Pi', 'ref_point': 'end',
+                                    'pulse_delay': delay})
+            else:
+                delay = \
+                    fp['pulse_length'] - np.min(
+                        sweep_points.get_sweep_params_property(
+                            'values', dimension=0, param_names='delay')) + \
+                    fp.get('buffer_length_end', 0) + fp.get('trans_length', 0)
+                b.block_end.update({'ref_pulse': 'FPS_Pi', 'ref_point': 'middle',
+                                    'pulse_delay': delay})
         else:
             b.block_end.update({'ref_pulse': 'FPS_Pi', 'ref_point': 'end',
                                 'pulse_delay': ro_pulse_delay})

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -297,7 +297,9 @@ class FluxPulseScope(ParallelLOSweepExperiment):
     kw_for_task_keys = ['ro_pulse_delay', 'fp_truncation',
                         'fp_truncation_buffer',
                         'fp_compensation',
-                        'fp_compensation_amp']
+                        'fp_compensation_amp',
+                        'fp_during_ro', 'tau',
+                        'fp_during_ro_length']
     kw_for_sweep_points = {
         'freqs': dict(param_name='freq', unit='Hz',
                       label=r'drive frequency, $f_d$',
@@ -319,7 +321,9 @@ class FluxPulseScope(ParallelLOSweepExperiment):
     def sweep_block(self, qb, sweep_points, flux_op_code=None,
                     ro_pulse_delay=None,
                     fp_truncation=False, fp_compensation=False,
-                    fp_compensation_amp=None, fp_truncation_buffer=None, **kw):
+                    fp_compensation_amp=None, fp_truncation_buffer=None,
+                    fp_during_ro=False, tau=None,
+                    fp_during_ro_length=None, **kw):
         """
         Performs X180 pulse on top of a fluxpulse
         Timings of sequence
@@ -336,6 +340,19 @@ class FluxPulseScope(ParallelLOSweepExperiment):
             the end of the flux pulse or a delay in seconds to start a fixed
             amount of time after the drive pulse. If not provided or set to
             None, a default fixed delay of 100e-9 is used.
+        :param fp_truncation: Truncate the flux pulse after the drive pulse
+        :param fp_truncation_buffer: Time buffer after the drive pulse, before
+            the truncation happens.
+        :param fp_compensation: Custom compensation for the charge build-up
+            in the bias T.
+        :param fp_compensation_amp: Fixed amplitude for the custom compensation
+            pulse.
+        :param fp_during_ro: Play a flux pulse during the read-out pulse to
+            bring the qubit actively to the parking position in the case where
+            the flux-pulse is not filtered yet.
+        :param fp_during_ro_length: Length of the fp_during_ro.
+        :param tau: Approximate dominant time constant in the flux line, which
+            is used to calculate the amplitude of the fp_during_ro.
 
         :param kw:
         """
@@ -347,17 +364,24 @@ class FluxPulseScope(ParallelLOSweepExperiment):
             fp_truncation_buffer = 5e-8
         if fp_compensation_amp is None:
             fp_compensation_amp = -2
+        if tau is None:
+            tau = 20e-6
+        if fp_during_ro_length is None:
+            fp_during_ro_length = 2e-6
 
         if ro_pulse_delay is 'auto' and (fp_truncation or \
             hasattr(fp_truncation, '__iter__')):
             raise Exception('fp_truncation does currently not work ' + \
                             'with the auto mode of ro_pulse_delay.')
 
+        assert not (fp_compensation and fp_during_ro)
+
         pulse_modifs = {'attr=name,op_code=X180': f'FPS_Pi',
                         'attr=element_name,op_code=X180': 'FPS_Pi_el'}
         b = self.block_from_ops(f'ge_flux {qb}',
                                 [f'X180 {qb}'] + [flux_op_code] * \
-                                (2 if fp_compensation else 1),
+                                (2 if fp_compensation else 1) \
+                                + ([f'FP {qb}'] if fp_during_ro else []),
                                 pulse_modifs=pulse_modifs)
 
         fp = b.pulses[1]
@@ -406,6 +430,32 @@ class FluxPulseScope(ParallelLOSweepExperiment):
 
                 cp['pulse_length'] = ParametricValue('delay', func=t_trunc)
                 # TODO: implement that the ro_delay is adjusted accordingly!
+
+            # TODO: this feature does not work if the delay is larger
+            # than the pulse length!
+            if fp_during_ro:
+                rfp = b.pulses[2]
+                rfp['pulse_delay'] = 0
+                rfp['pulse_length'] = fp_during_ro_length
+
+                def rfp_amp(x, fnc=length_function, tau=tau,
+                    fp_amp=fp['amplitude']):
+                    fp_length = fnc(x)
+                    return fp_amp * (1-np.exp(-fp_length/tau))
+
+                rfp['amplitude'] = ParametricValue('delay', func=rfp_amp)
+
+        else: #fp_truncation == False
+            # TODO: this feature does not work if the delay is larger
+            # than the pulse length!
+            if fp_during_ro:
+                rfp = b.pulses[2]
+                rfp['pulse_delay'] = 0
+                rfp['pulse_length'] = fp_during_ro_length
+
+                fp_amp = fp['amplitude']
+                fp_length = fp['pulse_length']
+                rfp['amplitude'] = fp_amp * (1-np.exp(-fp_length/tau))
 
         if ro_pulse_delay == 'auto':
             delay = \

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -383,8 +383,6 @@ class FluxPulseScope(ParallelLOSweepExperiment):
 
         assert not (fp_compensation and fp_during_ro)
 
-        assert not (fp_truncation and fp_during_ro)
-
         pulse_modifs = {'attr=name,op_code=X180': f'FPS_Pi',
                         'attr=element_name,op_code=X180': 'FPS_Pi_el'}
         b = self.block_from_ops(f'ge_flux {qb}',
@@ -404,6 +402,8 @@ class FluxPulseScope(ParallelLOSweepExperiment):
         fp['pulse_delay'] = ParametricValue(
             'delay', func=fp_delay)
 
+        fp_length_function = lambda x: fp['pulse_length']
+
         if (fp_truncation or hasattr(fp_truncation, '__iter__')):
             if not hasattr(fp_truncation, '__iter__'):
                 fp_truncation = [-np.inf, np.inf]
@@ -412,16 +412,13 @@ class FluxPulseScope(ParallelLOSweepExperiment):
                 sweep_points.get_sweep_params_property(
                     'values', dimension=0, param_names='delay'))
             sweep_diff = max(max_fp_sweep_length - original_fp_length, 0)
-            def length_function(x, opl=original_fp_length, \
-                o=bl_start + fp_truncation_buffer, trunc=fp_truncation):
-                if (x>np.min(trunc) and x<np.max(trunc)):
-                    return max(min((x + o), opl), 0)
-                else:
-                    return opl
+            fp_length_function = lambda x, opl=original_fp_length, \
+                o=bl_start + fp_truncation_buffer, trunc=fp_truncation: \
+                max(min((x + o), opl), 0) if (x>np.min(trunc) and x<np.max(trunc)) else opl
             # TODO: check what happens if buffer_length_start and buffer_length_end are zero.
 
             fp['pulse_length'] = ParametricValue(
-                'delay', func=length_function)
+                'delay', func=fp_length_function)
             if fp_compensation:
                 cp = b.pulses[2]
                 cp['amplitude'] = -np.sign(fp['amplitude']) * np.abs(
@@ -429,7 +426,7 @@ class FluxPulseScope(ParallelLOSweepExperiment):
                 cp['pulse_delay'] = sweep_diff + bl_start
                 tau = 200e-9 * 100
 
-                def t_trunc(x, fnc=length_function, tau=tau,
+                def t_trunc(x, fnc=fp_length_function, tau=tau,
                             fp_amp=fp['amplitude'], cp_amp=cp['amplitude']):
                     fp_length = fnc(x)
 
@@ -443,32 +440,31 @@ class FluxPulseScope(ParallelLOSweepExperiment):
                 cp['pulse_length'] = ParametricValue('delay', func=t_trunc)
                 # TODO: implement that the ro_delay is adjusted accordingly!
 
-        else: #fp_truncation == False
-            # assumes a unipolar flux-pulse for the calculation of the
-            # amplitude decay.
-            if fp_during_ro:
-                rfp = b.pulses[2]
+        # assumes a unipolar flux-pulse for the calculation of the
+        # amplitude decay.
+        if fp_during_ro:
+            rfp = b.pulses[2]
 
-                def rfp_delay(x, fp_delay=fp_delay, opl=fp['pulse_length'],\
-                    fp_bl_start=bl_start, fp_bl_end=bl_end):
-                    return -(opl+fp_bl_start+fp_bl_end+fp_delay(x))
+            def rfp_delay(x, fp_delay=fp_delay, fp_length=fp_length_function,\
+                fp_bl_start=bl_start, fp_bl_end=bl_end):
+                return -(fp_length(x)+fp_bl_start+fp_bl_end+fp_delay(x))
 
-                def rfp_amp(x, fp_delay=fp_delay, rfp_delay=rfp_delay, tau=tau,
-                    fp_amp=fp['amplitude'], o=fp_during_ro_buffer-bl_start):
-                    fp_length=-fp_delay(x)+o
-                    if fp_length <= 0:
-                        return 0
-                    elif rfp_delay(x) < 0:
-                        # in the middle of the fp
-                        return -fp_amp * np.exp(-fp_length / tau)
-                    else:
-                        # after the end of the fp
-                        return fp_amp * (1 - np.exp(-fp_length / tau))
+            def rfp_amp(x, fp_delay=fp_delay, rfp_delay=rfp_delay, tau=tau,
+                fp_amp=fp['amplitude'], o=fp_during_ro_buffer-bl_start):
+                fp_length=-fp_delay(x)+o
+                if fp_length <= 0:
+                    return 0
+                elif rfp_delay(x) < 0:
+                    # in the middle of the fp
+                    return -fp_amp * np.exp(-fp_length / tau)
+                else:
+                    # after the end of the fp
+                    return fp_amp * (1 - np.exp(-fp_length / tau))
 
-                rfp['pulse_length'] = fp_during_ro_length
-                rfp['pulse_delay'] = ParametricValue('delay', func=rfp_delay)
-                rfp['amplitude'] = ParametricValue('delay', func=rfp_amp)
-                rfp['buffer_length_start'] = fp_during_ro_buffer
+            rfp['pulse_length'] = fp_during_ro_length
+            rfp['pulse_delay'] = ParametricValue('delay', func=rfp_delay)
+            rfp['amplitude'] = ParametricValue('delay', func=rfp_amp)
+            rfp['buffer_length_start'] = fp_during_ro_buffer
 
         if ro_pulse_delay == 'auto':
             if fp_during_ro:

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -294,7 +294,7 @@ class FluxPulseScope(ParallelLOSweepExperiment):
         Returns: None
 
     """
-    kw_for_task_keys = ['ro_pulse_delay']
+    kw_for_task_keys = ['ro_pulse_delay', 'fp_truncation', 'fp_truncation_buffer']
     kw_for_sweep_points = {
         'freqs': dict(param_name='freq', unit='Hz',
                       label=r'drive frequency, $f_d$',
@@ -314,7 +314,8 @@ class FluxPulseScope(ParallelLOSweepExperiment):
             traceback.print_exc()
 
     def sweep_block(self, qb, sweep_points, flux_op_code=None,
-                    ro_pulse_delay=None, **kw):
+                    ro_pulse_delay=None,
+                    fp_truncation=None, fp_truncation_buffer=None, **kw):
         """
         Performs X180 pulse on top of a fluxpulse
         Timings of sequence
@@ -338,16 +339,52 @@ class FluxPulseScope(ParallelLOSweepExperiment):
             flux_op_code = f'FP {qb}'
         if ro_pulse_delay is None:
             ro_pulse_delay = 100e-9
+        if fp_truncation is None:
+            fp_truncation = False
+        if fp_truncation_buffer is None:
+            fp_truncation_buffer = 5e-8
+
+        if ro_pulse_delay is 'auto' and fp_truncation is True:
+            raise Exception('fp_truncation does currently not work ' + \
+                'with the auto mode of ro_pulse_delay.')
+
         pulse_modifs = {'attr=name,op_code=X180': f'FPS_Pi',
                         'attr=element_name,op_code=X180': 'FPS_Pi_el'}
         b = self.block_from_ops(f'ge_flux {qb}',
-                                [f'X180 {qb}', flux_op_code],
+                                [f'X180 {qb}'] + [flux_op_code] * \
+                                    (2 if fp_truncation else 1),
                                 pulse_modifs=pulse_modifs)
+    
         fp = b.pulses[1]
         fp['ref_point'] = 'middle'
-        offs = fp.get('buffer_length_start', 0)
+        bl_start = fp.get('buffer_length_start', 0)
+        bl_end = fp.get('buffer_length_end', 0)
+
         fp['pulse_delay'] = ParametricValue(
-            'delay', func=lambda x, o=offs: -(x + o))
+            'delay', func=lambda x, o=bl_start: -(x + o))
+
+        if fp_truncation:
+            cp = b.pulses[2]
+            original_fp_length = fp['pulse_length']
+            sweep_diff = np.abs(original_fp_length - \
+                            np.max( sweep_points.get_sweep_params_property(
+                                'values', dimension=0, param_names='delay')))
+            length_function = lambda x, opl=original_fp_length, \
+                o=bl_start+fp_truncation_buffer: max(min((x + o), opl), 0) # TODO: check what happens if buffer_length_start and buffer_length_end are zero.
+
+            fp['pulse_length'] = ParametricValue(
+                'delay', func=length_function)
+            cp['pulse_length'] = ro_pulse_delay - 2 * bl_start - 2 * bl_end \
+                                    - fp_truncation_buffer - sweep_diff
+            if cp['pulse_length'] <= 0:
+                raise Exception('ro_pulse_delay is too short to fit the ' + \
+                    'compensation pulse. Please choose a longer ro_pulse_delay.')
+            cp['pulse_delay'] = sweep_diff + bl_start
+            comp_amp_func = (lambda x, a=fp['amplitude'], cpl=cp['pulse_length'], \
+                                fnc=length_function: - a * fnc(x) / cpl)
+            cp['amplitude'] = ParametricValue(
+                'delay', func=comp_amp_func
+            )
 
         if ro_pulse_delay == 'auto':
             delay = \
@@ -362,7 +399,6 @@ class FluxPulseScope(ParallelLOSweepExperiment):
                                 'pulse_delay': ro_pulse_delay})
 
         self.data_to_fit.update({qb: 'pe'})
-
         return b
 
     def run_analysis(self, analysis_kwargs=None, **kw):

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -466,8 +466,12 @@ class FluxPulseScope(ParallelLOSweepExperiment):
                 def rfp_amp(x, length_func=length_func, rfp_delay=rfp_delay,
                     tau=tau, fp_amp=fp['amplitude']):
                     fp_length=length_func(x)
-                    return fp_amp*(-1+np.exp(-fp_length/tau)) \
-                        * (-1 if rfp_delay(x) > 0 else 1)
+                    if rfp_delay(x) < 0:
+                        # in the middle of the fp
+                        return -fp_amp * np.exp(-fp_length / tau)
+                    else:
+                        # after the end of the fp
+                        return fp_amp * (1 - np.exp(-fp_length / tau))
 
                 rfp['pulse_length'] = fp_during_ro_length
                 rfp['pulse_delay'] = ParametricValue('delay', func=rfp_delay)

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -398,8 +398,11 @@ class FluxPulseScope(ParallelLOSweepExperiment):
         bl_start = fp.get('buffer_length_start', 0)
         bl_end = fp.get('buffer_length_end', 0)
 
+        def fp_delay(x, o=bl_start):
+            return -(x+o)
+
         fp['pulse_delay'] = ParametricValue(
-            'delay', func=lambda x, o=bl_start: -(x + o))
+            'delay', func=fp_delay)
 
         if (fp_truncation or hasattr(fp_truncation, '__iter__')):
             if not hasattr(fp_truncation, '__iter__'):
@@ -446,16 +449,16 @@ class FluxPulseScope(ParallelLOSweepExperiment):
             if fp_during_ro:
                 rfp = b.pulses[2]
 
-                def length_func(x, offset=fp_during_ro_buffer):
-                    return max(x+offset, 0)
+                def rfp_delay(x, fp_delay=fp_delay, opl=fp['pulse_length'],\
+                    fp_bl_start=bl_start, fp_bl_end=bl_end):
+                    return -(opl+fp_bl_start+fp_bl_end+fp_delay(x))
 
-                def rfp_delay(x, length_func=length_func, opl=fp['pulse_length']):
-                    return -(opl-length_func(x))
-
-                def rfp_amp(x, length_func=length_func, rfp_delay=rfp_delay,
-                    tau=tau, fp_amp=fp['amplitude']):
-                    fp_length=length_func(x)
-                    if rfp_delay(x) < 0:
+                def rfp_amp(x, fp_delay=fp_delay, rfp_delay=rfp_delay, tau=tau,
+                    fp_amp=fp['amplitude'], o=fp_during_ro_buffer-bl_start):
+                    fp_length=-fp_delay(x)+o
+                    if fp_length <= 0:
+                        return 0
+                    elif rfp_delay(x) < 0:
                         # in the middle of the fp
                         return -fp_amp * np.exp(-fp_length / tau)
                     else:
@@ -465,6 +468,7 @@ class FluxPulseScope(ParallelLOSweepExperiment):
                 rfp['pulse_length'] = fp_during_ro_length
                 rfp['pulse_delay'] = ParametricValue('delay', func=rfp_delay)
                 rfp['amplitude'] = ParametricValue('delay', func=rfp_amp)
+                rfp['buffer_length_start'] = fp_during_ro_buffer
 
         if ro_pulse_delay == 'auto':
             if fp_during_ro:

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -447,7 +447,7 @@ class FluxPulseScope(ParallelLOSweepExperiment):
 
             def rfp_delay(x, fp_delay=fp_delay, fp_length=fp_length_function,\
                 fp_bl_start=bl_start, fp_bl_end=bl_end):
-                return -(fp_length(x)+fp_bl_start+fp_bl_end+fp_delay(x))
+                return -(fp_length(x)+fp_bl_end+fp_delay(x))
 
             def rfp_amp(x, fp_delay=fp_delay, rfp_delay=rfp_delay, tau=tau,
                 fp_amp=fp['amplitude'], o=fp_during_ro_buffer-bl_start):

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -352,8 +352,10 @@ class FluxPulseScope(ParallelLOSweepExperiment):
             pulse.
         :param fp_during_ro: Play a flux pulse during the read-out pulse to
             bring the qubit actively to the parking position in the case where
-            the flux-pulse is not filtered yet.
+            the flux-pulse is not filtered yet. This assumes a unipolar flux-pulse.
         :param fp_during_ro_length: Length of the fp_during_ro.
+        :param fp_during_ro_buffer: Time buffer between the drive pulse and
+            the fp_during_ro
         :param tau: Approximate dominant time constant in the flux line, which
             is used to calculate the amplitude of the fp_during_ro.
 
@@ -438,23 +440,9 @@ class FluxPulseScope(ParallelLOSweepExperiment):
                 cp['pulse_length'] = ParametricValue('delay', func=t_trunc)
                 # TODO: implement that the ro_delay is adjusted accordingly!
 
-            # TODO: this feature does not work if the delay is larger
-            # than the pulse length!
-            # if fp_during_ro:
-            #     rfp = b.pulses[2]
-            #     rfp['pulse_delay'] = 0
-            #     rfp['pulse_length'] = fp_during_ro_length
-
-            #     def rfp_amp(x, fnc=length_function, tau=tau,
-            #         fp_amp=fp['amplitude']):
-            #         fp_length = fnc(x)
-            #         return fp_amp * (1-np.exp(-fp_length/tau))
-
-            #     rfp['amplitude'] = ParametricValue('delay', func=rfp_amp)
-
         else: #fp_truncation == False
-            # TODO: this feature does not work if the delay is larger
-            # than the pulse length!
+            # assumes a unipolar flux-pulse for the calculation of the
+            # amplitude decay.
             if fp_during_ro:
                 rfp = b.pulses[2]
 


### PR DESCRIPTION
This PR adds multiple new features to the FP Scope measurement, such as truncating the flux pulse after the readout or returning to the parking position before readout based on a guess model for the high pass characteristic of the bias T. It also introduces improvements in analysis such as creating a log plot or fitting a mixture of two Gaussians per slice (instead of a single Gaussian).

@RichardBoell and @stephlazar can you please mutually review each other's changes? I approve :-) 

FYI @nathlacroix 