### PR TITLE
Segment sweep points and possibility to sweep over distortion dicts

### DIFF
--- a/pycqed/measurement/waveform_control/circuit_builder.py
+++ b/pycqed/measurement/waveform_control/circuit_builder.py
@@ -861,11 +861,10 @@ class CircuitBuilder:
                 for dim in [0, 1]:
                     if len(sweep_points[dim]) == 0:
                         continue
-                    for param, vals in [
-                            [s[2], s[0]] for s in
-                            sweep_points.get_sweep_params_description(
-                                'all', dimension=dim)]:
+                    for param in sweep_points[dim]:
                         if param.startswith('Segment.'):
+                            vals = sweep_points.get_sweep_params_property(
+                                'values', dim, param)
                             setattr(seg, param[len('Segment.'):],
                                     vals[j if dim == 0 else i])
                 # add the new segment to the sequence

--- a/pycqed/measurement/waveform_control/circuit_builder.py
+++ b/pycqed/measurement/waveform_control/circuit_builder.py
@@ -755,6 +755,9 @@ class CircuitBuilder:
         Currently, only 1D and 2D sweeps are implemented.
 
         :param sweep_points: SweepPoints object
+            Note: If it contains sweep points with parameter names of the form
+            "Segment.property", the respective property of the created
+            Segment objects will be swept.
         :param body_block: block containing the pulses to be swept (excluding
             initialization and readout)
         :param body_block_func: a function that creates the body block at each
@@ -852,8 +855,21 @@ class CircuitBuilder:
 
                 segblock = self.sequential_blocks(
                         'segblock', [prep, this_body_block, final, ro])
-                seq.add(Segment(f'seg{j}', segblock.build(
-                    sweep_dicts_list=sweep_points, sweep_index_list=[j, i])))
+                seg = Segment(f'seg{j}', segblock.build(
+                    sweep_dicts_list=sweep_points, sweep_index_list=[j, i]))
+                # apply Segment sweep points
+                for dim in [0, 1]:
+                    if len(sweep_points[dim]) == 0:
+                        continue
+                    for param, vals in [
+                            [s[2], s[0]] for s in
+                            sweep_points.get_sweep_params_description(
+                                'all', dimension=dim)]:
+                        if param.startswith('Segment.'):
+                            setattr(seg, param[len('Segment.'):],
+                                    vals[j if dim == 0 else i])
+                # add the new segment to the sequence
+                seq.add(seg)
             if cal_points is not None:
                 seq.extend(cal_points.create_segments(self.operation_dict,
                                                       **self.get_prep_params()))

--- a/pycqed/measurement/waveform_control/circuit_builder.py
+++ b/pycqed/measurement/waveform_control/circuit_builder.py
@@ -859,8 +859,6 @@ class CircuitBuilder:
                     sweep_dicts_list=sweep_points, sweep_index_list=[j, i]))
                 # apply Segment sweep points
                 for dim in [0, 1]:
-                    if len(sweep_points[dim]) == 0:
-                        continue
                     for param in sweep_points[dim]:
                         if param.startswith('Segment.'):
                             vals = sweep_points.get_sweep_params_property(

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -22,6 +22,10 @@ class Segment:
     Consists of a list of UnresolvedPulses, each of which contains information 
     about in which element the pulse is played and when it is played 
     (reference point + delay) as well as an instance of class Pulse.
+
+    Property distortion_dicts: a key of the form {AWG}_{channel} specifies
+        that the respective val should be used as distortion dict instead of
+        self.pulsar.{AWG}_{channel}_distortion_dict.
     """
 
     trigger_pulse_length = 20e-9
@@ -37,6 +41,7 @@ class Segment:
         self.elements = odict()
         self.element_start_end = {}
         self.elements_on_awg = {}
+        self.distortion_dicts = {}
         self.trigger_pars = {
             'pulse_length': self.trigger_pulse_length,
             'amplitude': self.trigger_pulse_amplitude,
@@ -897,9 +902,18 @@ class Segment:
 
                         wf = wfs[codeword][c]
 
-                        distortion_dictionary = self.pulsar.get(
-                            '{}_distortion_dict'.format(c))
-                        fir_kernels = distortion_dictionary.get('FIR', None)
+                        distortion_dict = self.distortion_dicts.get(c, None)
+                        if distortion_dict is None:
+                            distortion_dict = self.pulsar.get(
+                                '{}_distortion_dict'.format(c))
+                        else:
+                            distortion_dict = \
+                                flux_dist.process_filter_coeffs_dict(
+                                    distortion_dict,
+                                    default_dt=1 / self.pulsar.clock(
+                                        channel=c))
+
+                        fir_kernels = distortion_dict.get('FIR', None)
                         if fir_kernels is not None:
                             if hasattr(fir_kernels, '__iter__') and not \
                             hasattr(fir_kernels[0], '__iter__'): # 1 kernel
@@ -907,7 +921,7 @@ class Segment:
                             else:
                                 for kernel in fir_kernels:
                                     wf = flux_dist.filter_fir(kernel, wf)
-                        iir_filters = distortion_dictionary.get('IIR', None)
+                        iir_filters = distortion_dict.get('IIR', None)
                         if iir_filters is not None:
                             wf = flux_dist.filter_iir(iir_filters[0],
                                                       iir_filters[1], wf)


### PR DESCRIPTION
This PR enables CircuitBuilder.sweep_n_dim to sweep over a property of the created Segment objects. As a use case, the PR adds the property distortion_dicts to Segment, which (if it is set) supersedes the respective setting in pulsar. This enables us to implement a sweep over distortion_dicts in order to compare the effect of different flux line predistortion filters.

A small PR that should not be very difficult to review for @stephlazar .
FYI @nathlacroix 
