### PR TITLE
QE/CalibBuilder: Improved behavior of autorun

### DIFF
--- a/pycqed/measurement/calibration/two_qubit_gates.py
+++ b/pycqed/measurement/calibration/two_qubit_gates.py
@@ -562,7 +562,7 @@ class CalibBuilder(MultiTaskingExperiment):
         """
         self.update = update
         self.callback = kw.get('callback', self.run_update)
-        self.callback_condition = lambda : self.update
+        self.callback_condition = lambda : self.update and self.analyze
 
     def run_update(self, **kw):
         # must be overriden by child classes to update the

--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -339,12 +339,12 @@ class QuantumExperiment(CircuitBuilder):
             except (Exception, KeyboardInterrupt) as e:
                 self.save_timers()
                 raise e
-        if self.analyze:
-            self.run_analysis(**kw)
-        if self.callback is not None and self.callback_condition():
-            self.callback(**kw)
-        if self.measure: # for now store timers only if creating new file
-            self.save_timers()
+            # analyze and call callback only when measuring
+            if self.analyze:
+                self.run_analysis(**kw)
+            if self.callback is not None and self.callback_condition():
+                self.callback(**kw)
+            self.save_timers()  # for now store timers only if creating new file
         return self
 
     def serialize(self, omitted_attrs=('MC', 'device', 'qubits')):


### PR DESCRIPTION
QuantumExperiment.autorun: do not analyze and call callback if measure is False
CalibBuilder: prevent autorun from calling run_update if analyze is False

very quick to review for @stephlazar 
FYI @nathlacroix 