### PR TITLE
Bugfix: proper handling of param_to_set in reload function

### DIFF
--- a/pycqed/utilities/general.py
+++ b/pycqed/utilities/general.py
@@ -206,8 +206,10 @@ def load_settings(instrument,
             if verbose:
                 print('Loaded settings successfully from the HDF file.')
 
-            params_to_set = kw.pop('params_to_set', [])
-            if len(params_to_set)>0:
+            params_to_set = kw.pop('params_to_set', None)
+            if params_to_set is not None:
+                if len(params_to_set) == 0:
+                    log.warning('The list of parameters to update is empty.')
                 if verbose and update:
                     print('Setting parameters {} for {}.'.format(
                         params_to_set, instrument_name))


### PR DESCRIPTION
Ensures that an empty list of settings leads to no parameters being reloaded,
and that all params are loaded only if params_to_set is None.

Warns the user if the list of settings to update is empty, as this
should rarely be the case.

Inviting @chellings  to review.


