### PR TITLE
Device: avoid error message about trying to reload qubits

### DIFF
--- a/pycqed/instrument_drivers/meta_instrument/device.py
+++ b/pycqed/instrument_drivers/meta_instrument/device.py
@@ -38,6 +38,10 @@ log = logging.getLogger(__name__)
 
 
 class Device(Instrument):
+    # params that should not be loaded by pycqed.utilities.general.load_settings
+    _params_to_not_load = {'qubits'}
+
+
     def __init__(self, name, qubits, connectivity_graph, **kw):
         """
         Instantiates device instrument and adds its parameters.

--- a/pycqed/utilities/general.py
+++ b/pycqed/utilities/general.py
@@ -217,7 +217,10 @@ def load_settings(instrument,
             else:
                 if verbose and update:
                     print('Setting parameters for {}.'.format(instrument_name))
-                params_to_set = ins_group.attrs.items()
+                params_to_set = [
+                    (param, val) for (param, val) in ins_group.attrs.items()
+                    if param not in getattr(
+                        instrument, '_params_to_not_load', {})]
 
             if not update:
                 params_dict = {parameter : value for parameter, value in \


### PR DESCRIPTION
- utilities.general: allow instruments to specify _params_to_not_load: These parameters won't be reloaded except if the user explicitly passed them in params_to_set.
- Device: tell general.load_settings to not reload the qubits parameter 