### PR TITLE
QE self.df and check UHF acquisitions limit

### DIFF
--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -523,18 +523,18 @@ class UHFQC_Base(Hard_Detector):
 
                 # For the integration logging detector,
                 # nr_sweep_points = nr_shots * nr_segments
-                total_nr_acq = d.nr_sweep_points
+                total_nr_shots_acq = d.nr_sweep_points
                 if hasattr(d, 'classified'):
                     # For the classifier detector
                     # nr_sweep_points = nr_segments like for the integrated
                     # averaged detector, but the UHF is programmed to return
                     # single shots.
-                    total_nr_acq *= d.nr_shots
-                if total_nr_acq > 2**20:
+                    total_nr_shots_acq *= d.nr_shots
+                if total_nr_shots_acq > 2**20:
                     raise ValueError(f'For detector function number {i}, '
                                      f'({d.name}) nr. segments * nr. shots = '
-                                     f'{total_nr_acq} > 1048576 supported by '
-                                     f'the UHF. Please reduce the '
+                                     f'{total_nr_shots_acq} > 1048576 '
+                                     f'supported by the UHF. Please reduce the '
                                      f'compression_seg_lim, the number of 1D '
                                      f'sweep points, or the nr_shots.')
 

--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -516,7 +516,7 @@ class UHFQC_Base(Hard_Detector):
         Currently, it only checks whether the total number of acquisitions is
         supported by the UHF (1048576 is hardcoded).
         """
-        print('here')
+
         for i, d in enumerate(self.detectors):
             if hasattr(d, 'nr_shots'):
                 # Either integration_logging_det or classifier_detector

--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -513,8 +513,9 @@ class UHFQC_Base(Hard_Detector):
         """
         This method should be used to check whether the measurement settings
         are supported by the hardware.
-        Currently, it only checks whether the total number of acquisitions is
-        supported by the UHF (1048576 is hardcoded).
+        Currently, it only checks whether the total number of acquisitions in
+        case of a single-shot readout is supported by the UHF
+        (1048576 is hardcoded).
         """
 
         for i, d in enumerate(self.detectors):

--- a/pycqed/measurement/detector_functions.py
+++ b/pycqed/measurement/detector_functions.py
@@ -509,6 +509,35 @@ class UHFQC_Base(Hard_Detector):
         self.UHF_map = {UHF.name: i
                    for UHF, i in zip(self.UHFs, range(len(self.detectors)))}
 
+    def _check_hardware_limitations(self):
+        """
+        This method should be used to check whether the measurement settings
+        are supported by the hardware.
+        Currently, it only checks whether the total number of acquisitions is
+        supported by the UHF (1048576 is hardcoded).
+        """
+        print('here')
+        for i, d in enumerate(self.detectors):
+            if hasattr(d, 'nr_shots'):
+                # Either integration_logging_det or classifier_detector
+
+                # For the integration logging detector,
+                # nr_sweep_points = nr_shots * nr_segments
+                total_nr_acq = d.nr_sweep_points
+                if hasattr(d, 'classified'):
+                    # For the classifier detector
+                    # nr_sweep_points = nr_segments like for the integrated
+                    # averaged detector, but the UHF is programmed to return
+                    # single shots.
+                    total_nr_acq *= d.nr_shots
+                if total_nr_acq > 2**20:
+                    raise ValueError(f'For detector function number {i}, '
+                                     f'({d.name}) nr. segments * nr. shots = '
+                                     f'{total_nr_acq} > 1048576 supported by '
+                                     f'the UHF. Please reduce the '
+                                     f'compression_seg_lim, the number of 1D '
+                                     f'sweep points, or the nr_shots.')
+
     @Timer()
     def poll_data(self):
         if self.AWG is not None:
@@ -743,6 +772,7 @@ class UHFQC_input_average_detector(UHFQC_Base):
         if self.AWG is not None:
             self.AWG.stop()
         self.nr_sweep_points = self.nr_samples
+        self._check_hardware_limitations()
         self.UHFQC.qudev_acquisition_initialize(channels=self.channels, 
                                           samples=self.nr_samples,
                                           averages=self.nr_averages,
@@ -984,6 +1014,8 @@ class UHFQC_integrated_average_detector(UHFQC_Base):
             if self.prepare_function is not None:
                 self.prepare_function()
 
+        self._check_hardware_limitations()
+
         # Do not enable the rerun button; the AWG program uses userregs/0 to
         # define the number of iterations in the loop
         self.UHFQC.awgs_0_single(1)
@@ -1066,6 +1098,7 @@ class UHFQC_correlation_detector(UHFQC_integrated_average_detector):
             self.nr_sweep_points = self.seg_per_point
         else:
             self.nr_sweep_points = len(sweep_points) * self.seg_per_point
+        self._check_hardware_limitations()
 
         self.UHFQC.qas_0_integration_length(int(self.integration_length*(1.8e9)))
 
@@ -1263,13 +1296,13 @@ class UHFQC_integration_logging_det(UHFQC_Base):
             if self.prepare_function is not None:
                 self.prepare_function()
 
+        self.nr_sweep_points = len(sweep_points)
+        self._check_hardware_limitations()
+
         # The averaging-count is used to specify how many times the AWG program
         # should run
         self.UHFQC.awgs_0_single(1)
-
-        self.nr_sweep_points = len(sweep_points)
         self.UHFQC.qas_0_integration_length(int(self.integration_length*1.8e9))
-
         self.UHFQC.qas_0_result_source(self.result_logging_mode_idx)
         self.UHFQC.qudev_acquisition_initialize(channels=self.channels, 
                                           samples=self.nr_sweep_points,
@@ -1393,6 +1426,8 @@ class UHFQC_classifier_detector(UHFQC_integration_logging_det):
 
         assert len(sweep_points) % self.acq_data_len_scaling == 0
         self.nr_sweep_points = len(sweep_points) // self.acq_data_len_scaling
+        self._check_hardware_limitations()
+
         # The averaging-count is used to specify how many times the AWG program
         # should run
         self.UHFQC.awgs_0_single(1)

--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -249,8 +249,6 @@ class QuantumExperiment(CircuitBuilder):
             # configure measurement control (mc_points, detector functions)
             mode = self._configure_mc()
 
-            self._check_hardware_limitations()
-
             self.guess_label(**kw)
 
             self.update_metadata()
@@ -588,25 +586,6 @@ class QuantumExperiment(CircuitBuilder):
                                      "objects were found. Pass the MC to "
                                      "run_measurement() or set the MC attribute"
                                      " of the QuantumExperiment instance.")
-
-    def _check_hardware_limitations(self):
-        """
-        This method should be used to check whether the measurement settings
-        are supported by the hardware.
-        Currently, it only checks whether the total number of acquisitions is
-        supported by the UHF (1048576 is hardcoded).
-        """
-        d = self.df
-        if hasattr(self.df, 'detectors'):
-            d = self.df.detectors[0]
-
-        if hasattr(d, 'nr_shots'):
-            nr_shots = d.nr_shots
-            nr_acq = self.mc_points[0].size * nr_shots
-            if nr_acq > 2**20:
-                raise ValueError(f'Nr. segments * nr. shots = {nr_acq} > '
-                                 f'1048576 supported by the UHF. Please change '
-                                 f'the compression_seg_lim or reduce nr_shots.')
 
     # def __setattr__(self, name, value):
     #     """

--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -249,6 +249,8 @@ class QuantumExperiment(CircuitBuilder):
             # configure measurement control (mc_points, detector functions)
             mode = self._configure_mc()
 
+            self._check_hardware_limitations()
+
             self.guess_label(**kw)
 
             self.update_metadata()
@@ -586,6 +588,25 @@ class QuantumExperiment(CircuitBuilder):
                                      "objects were found. Pass the MC to "
                                      "run_measurement() or set the MC attribute"
                                      " of the QuantumExperiment instance.")
+
+    def _check_hardware_limitations(self):
+        """
+        This method should be used to check whether the measurement settings
+        are supported by the hardware.
+        Currently, it only checks whether the total number of acquisitions is
+        supported by the UHF (1048576 is hardcoded).
+        """
+        d = self.df
+        if hasattr(self.df, 'detectors'):
+            d = self.df.detectors[0]
+
+        if hasattr(d, 'nr_shots'):
+            nr_shots = d.nr_shots
+            nr_acq = self.mc_points[0].size * nr_shots
+            if nr_acq > 2**20:
+                raise ValueError(f'Nr. segments * nr. shots = {nr_acq} > '
+                                 f'1048576 supported by the UHF. Please change '
+                                 f'the compression_seg_lim or reduce nr_shots.')
 
     # def __setattr__(self, name, value):
     #     """

--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -542,15 +542,15 @@ class QuantumExperiment(CircuitBuilder):
 
         # Configure detector function
         # FIXME: this should be extended to meas_objs that are not qubits
-        df = mqm.get_multiplexed_readout_detector_functions(
+        self.df = mqm.get_multiplexed_readout_detector_functions(
             self.meas_objs, **self.df_kwargs)[self.df_name]
-        self.MC.set_detector_function(df)
+        self.MC.set_detector_function(self.df)
         if self.dev is not None:
             meas_obj_value_names_map = self.dev.get_meas_obj_value_names_map(
-                self.meas_objs, df)
+                self.meas_objs, self.df)
         else:
             meas_obj_value_names_map = mqm.get_meas_obj_value_names_map(
-                self.meas_objs, df)
+                self.meas_objs, self.df)
         self.exp_metadata.update(
             {'meas_obj_value_names_map': meas_obj_value_names_map})
         if 'meas_obj_sweep_points_map' not in self.exp_metadata:


### PR DESCRIPTION
Changes proposed in this pull request only affect QuantumExperiment:
- overwrite self.df (set to None in __init__) with the detector function instance created in _configure_mc()
- add _check_hardware_limitations() which currently only checks whether the total number of acquisitions in one upload does not exceed 2**20 which is a UHF limitation. Can be extended to further checks in the future.

I've lost count how many nights I've wasted because this check was missing ...

FYI @nathlacroix 
