### PR TITLE
QuDev_transmon.prepare: enable external gating for pulsed spec with SGS100

### DIFF
--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -831,6 +831,8 @@ class QuDev_transmon(Qubit):
                 ge_lo.get_instr().on()
             elif drive == 'pulsed_spec':
                 ge_lo.get_instr().pulsemod_state('On')
+                if 'pulsemod_source' in ge_lo.get_instr().parameters:
+                    ge_lo.get_instr().pulsemod_source('EXT')
                 ge_lo.get_instr().power(self.spec_power())
                 ge_lo.get_instr().frequency(self.ge_freq())
                 ge_lo.get_instr().on()


### PR DESCRIPTION
The pulsemod_source has to be set to external in the SGS100. Otherwise, the output is always on.

Tested at BF1

2 lines of code to review for @antsr 
FYI @nathlacroix @stephlazar 