### PR TITLE
Use format in savefig

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -697,13 +697,13 @@ class BaseDataAnalysis(object):
             if self.presentation_mode:
                 savename = os.path.join(savedir, savebase + key + tstag + 'presentation' + '.' + fmt)
                 self.figs[key].savefig(savename, bbox_inches='tight',
-                                       fmt=fmt, dpi=dpi)
+                                       format=fmt, dpi=dpi)
                 savename = os.path.join(savedir, savebase + key + tstag + 'presentation' + '.svg')
-                self.figs[key].savefig(savename, bbox_inches='tight', fmt='svg')
+                self.figs[key].savefig(savename, bbox_inches='tight', format='svg')
             else:
                 savename = os.path.join(savedir, savebase + key + tstag + '.' + fmt)
                 self.figs[key].savefig(savename, bbox_inches='tight',
-                                       fmt=fmt, dpi=dpi)
+                                       format=fmt, dpi=dpi)
             if close_figs:
                 plt.close(self.figs[key])
 

--- a/pycqed/analysis_v3/saving.py
+++ b/pycqed/analysis_v3/saving.py
@@ -205,16 +205,16 @@ class Save:
                 savename = os.path.join(self.savedir, savebase + key + tstag +
                                         'presentation' + '.' + fmt)
                 figs_dicts[key].savefig(savename, bbox_inches='tight',
-                                       fmt=fmt, dpi=dpi)
+                                        format=fmt, dpi=dpi)
                 savename = os.path.join(self.savedir, savebase + key + tstag +
                                         'presentation' + '.svg')
                 figs_dicts[key].savefig(savename, bbox_inches='tight',
-                                        fmt='svg')
+                                        format='svg')
             else:
                 savename = os.path.join(self.savedir, savebase + key + tstag
                                         + '.' + fmt)
                 figs_dicts[key].savefig(savename, bbox_inches='tight',
-                                       fmt=fmt, dpi=dpi)
+                                        format=fmt, dpi=dpi)
             if params.get('close_figs', True):
                 plt.close(figs_dicts[key])
 


### PR DESCRIPTION
Replaces fmt by format in calls to savefig in BaseDataAnalysis and analysis_v3/saving.py. fmt keyword argument will no longer be supposed in Matplotlib 3.3. This should not break anything for users who have an older version.

Quick to review for @chellings as we discussed.
