### PR TITLE
Bugfixes in Segment: enforce_single_element and renaming

### DIFF
--- a/pycqed/measurement/waveform_control/pulse.py
+++ b/pycqed/measurement/waveform_control/pulse.py
@@ -140,7 +140,11 @@ class Pulse:
             channels = self.channels
         else:
             channels = [ch for m, ch in zip(channel_mask, self.channels) if m]
-        return set(channels) | set(self.crosstalk_cancellation_channels)
+        if any([ch in self.crosstalk_cancellation_channels for ch in
+                channels]):
+            return set(channels) | set(self.crosstalk_cancellation_channels)
+        else:
+            return set(channels)
 
     def pulse_area(self, channel, tvals):
         """

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -170,7 +170,7 @@ class Segment:
                     self.pulsar.get(f'{ch_awg}_enforce_single_element'))
             if all(ch_mask) and len(ch_mask) != 0:
                 p = deepcopy(p)
-                p.pulse_obj.element_name = f'default_{self.name}'
+                p.pulse_obj.element_name = f'default_ese_{self.name}'
                 self.resolved_pulses.append(p)
             elif any(ch_mask):
                 p0 = deepcopy(p)

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -1466,6 +1466,9 @@ class Segment:
                             f'current element name when renaming '
                             f'the segment.')
         self.acquisition_elements = new_acq_elements
+        # enforce that start and end times get recalculated using the new
+        # element names
+        self.element_start_end = {}
 
         # rename segment name
         self.name = new_name

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -178,7 +178,7 @@ class Segment:
                 self.resolved_pulses.append(p0)
 
                 p1 = deepcopy(p)
-                p1.pulse_obj.element_name = f'default_{self.name}'
+                p1.pulse_obj.element_name = f'default_ese_{self.name}'
                 p1.pulse_obj.channel_mask = ch_mask
                 p1.ref_pulse = p.pulse_obj.name
                 p1.ref_point = 0

--- a/pycqed/measurement/waveform_control/sequence.py
+++ b/pycqed/measurement/waveform_control/sequence.py
@@ -237,7 +237,7 @@ class Sequence:
                 segment_counter += seq.n_segments()
 
                 # update name of merged seq
-                merged_seqs[-1].name += "+" + seq.name
+                merged_seqs[-1].rename(merged_seqs[-1].name + Sequence.RENAMING_SEPARATOR + seq.name)
                 if merge_repeat_patterns:
                     for ch_name, pattern in seq.repeat_patterns.items():
                         # if channel is already present, update number of
@@ -262,7 +262,11 @@ class Sequence:
                         else:
                             merged_seqs[-1].repeat_patterns.update(
                                 {ch_name: pattern})
-
+        # compress names
+        for ms in merged_seqs:
+            name_parts = ms.name.split(Sequence.RENAMING_SEPARATOR)
+            if len(name_parts) > 1:
+                ms.rename(f"compressed_{name_parts[0]}-{name_parts[-1]}")
         return merged_seqs
 
     @staticmethod
@@ -358,6 +362,10 @@ class Sequence:
             soft_sp_ind = np.arange(len(compressed_2D_sweep))
 
         return compressed_2D_sweep, hard_sp_ind, soft_sp_ind, factor
+
+    def rename(self, new_name):
+        self.name = new_name
+        self.timer.name = new_name
 
     def __repr__(self):
         string_repr = f"####### {self.name} #######\n"

--- a/pycqed/measurement/waveform_control/sequence.py
+++ b/pycqed/measurement/waveform_control/sequence.py
@@ -265,7 +265,7 @@ class Sequence:
         # compress names
         for ms in merged_seqs:
             name_parts = ms.name.split(Sequence.RENAMING_SEPARATOR)
-            if len(name_parts) > 1:
+            if len(name_parts) > 2:
                 ms.rename(f"compressed_{name_parts[0]}-{name_parts[-1]}")
         return merged_seqs
 


### PR DESCRIPTION
- bugfix Pulse: allow using crosstalk cancellation togther with enforce single element (ese)
- use special element name for ese elements
- bugfix Segment.rename: enforce that start and end times get recalculated using the new element names
- Compress names of compressed sequences

Used for a while already at XLD. Also note the additional explanations in the commit messages.

Inviting @antsr to review
FYI @stephlazar @nathlacroix 

