### PR TITLE
Various improvements and bugfixes in CircuitBuilder, Block, and Segment

### DIFF
--- a/pycqed/measurement/waveform_control/block.py
+++ b/pycqed/measurement/waveform_control/block.py
@@ -64,7 +64,7 @@ class Block:
             (ref)pulse name (before a potential change in a previous build())
             matches.
 
-            'attr=X, key_1=val_1, ..., key_N=val_N, occurence=i'
+            'attr=X, key_1=val_1, ..., key_N=val_N, occurrence=i'
             Sweep the attribute only for the ith pulse matching the
             criteria, where i is an integer (zero-indexed)
 

--- a/pycqed/measurement/waveform_control/block.py
+++ b/pycqed/measurement/waveform_control/block.py
@@ -247,6 +247,8 @@ class Block:
                                 p[attr], p['op_code'] = s.resolve(
                                     sweep_dict, ind, p['op_code'])
                             else:
+                                # allows to add ParametricValues to block_start
+                                # or block_end. See for ex the T1 class
                                 p[attr] = s.resolve(sweep_dict, ind)
 
         # resolve pulse modifiers now (they could overwrite parametric values)

--- a/pycqed/measurement/waveform_control/block.py
+++ b/pycqed/measurement/waveform_control/block.py
@@ -243,8 +243,11 @@ class Block:
                 if getattr(s, '_is_parametric_value', False):
                     for sweep_dict, ind in zip(sweep_dicts_list, index_list):
                         if s.param in sweep_dict:
-                            p[attr], p['op_code'] = s.resolve(
-                                sweep_dict, ind, p['op_code'])
+                            if 'op_code' in p:
+                                p[attr], p['op_code'] = s.resolve(
+                                    sweep_dict, ind, p['op_code'])
+                            else:
+                                p[attr] = s.resolve(sweep_dict, ind)
 
         # resolve pulse modifiers now (they could overwrite parametric values)
         def check_candidate(k, v, p):

--- a/pycqed/measurement/waveform_control/circuit_builder.py
+++ b/pycqed/measurement/waveform_control/circuit_builder.py
@@ -103,7 +103,8 @@ class CircuitBuilder:
             qb_names = [qb_names]
 
         # test if qubit objects have been provided instead of names
-        qb_names = [qb if isinstance(qb, str) else qb.name for qb in qb_names]
+        qb_names = [qb if isinstance(qb, str) or isinstance(qb, int)
+                    else qb.name for qb in qb_names]
         # test if qubit indices have been provided instead of names
         try:
             ind = [int(i) for i in qb_names]

--- a/pycqed/measurement/waveform_control/circuit_builder.py
+++ b/pycqed/measurement/waveform_control/circuit_builder.py
@@ -205,7 +205,8 @@ class CircuitBuilder:
         op_name = op_info[0][1:] if op_info[0][0] == 's' else op_info[0]
         op = op_name + ' ' + ' '.join(op_info[1:])
 
-        if op_name.startswith('CZ'):
+        if op_info[0].rstrip('0123456789.') == 'CZ' or \
+                op_info[0].startswith('CZ:'):
             operation = self.get_cz_operation_name(op_info[1], op_info[2])
             p = deepcopy(self.operation_dict[operation])
         elif parse_rotation_gates and op not in self.operation_dict:

--- a/pycqed/measurement/waveform_control/circuit_builder.py
+++ b/pycqed/measurement/waveform_control/circuit_builder.py
@@ -222,7 +222,13 @@ class CircuitBuilder:
                 raise KeyError(f'Gate "{op}" not found.')
             angle, qbn = op_name[1:], op_info[1]
             if angle[-1] == 's' and angle[:-1].isnumeric():
-                # Simultaneous virtual Z pulses (ex: Z90s qb1)
+                # For non-parametric gates, an alternative syntax for
+                # simultaneous pulses with appended s instead of prepended s
+                # is allowed. This code branch treats, e.g., simultaneous
+                # virtual Z pulses (like 'Z90s qb1') and simultaneous X/Y
+                # rotations with angles different from 90 and 180
+                # (like 'X45s qb1'; X90s and X180s are contained in the
+                # operations dict anyways, but no other angles).
                 op_info[0] = 's' + op_info[0]
                 angle = angle[:-1]
             param = None
@@ -866,6 +872,14 @@ class CircuitBuilder:
                             'values', 'all', 'finalize')[dims[sweep_dim_final]],
                         qb_names=all_ro_qubits, **final_kwargs)
 
+                # As we loop over all sweep points, some of the blocks will be
+                # built multiple times (e.g., ro), but they will only be
+                # built once per segment. It is thus not necessary to append
+                # a counter that is increased each time the block is built.
+                # Quite the contrary, it is much more intuitive to have the
+                # same block names in each segment, while only the segment
+                # name reflects the index of the sweep point. Thus, we call
+                # sequential_blocks with disable_block_counter=True.
                 segblock = self.sequential_blocks(
                     'segblock', [prep, this_body_block, final, ro],
                     disable_block_counter=True)

--- a/pycqed/measurement/waveform_control/circuit_builder.py
+++ b/pycqed/measurement/waveform_control/circuit_builder.py
@@ -220,6 +220,8 @@ class CircuitBuilder:
             if op_name[0] not in ['X', 'Y', 'Z']:
                 raise KeyError(f'Gate "{op}" not found.')
             angle, qbn = op_name[1:], op_info[1]
+            if angle[-1] == 's':
+                angle = angle[:-1]
             param = None
             if angle[0] == ':':  # angle depends on a parameter
                 angle = angle[1:]
@@ -611,7 +613,6 @@ class CircuitBuilder:
             pulse_modifs = {}
         if isinstance(operations, str):
             operations = [operations]
-
         pulses = [self.get_pulse(op_format(op, **fill_values), True)
                   for op in operations]
 

--- a/pycqed/measurement/waveform_control/circuit_builder.py
+++ b/pycqed/measurement/waveform_control/circuit_builder.py
@@ -222,6 +222,7 @@ class CircuitBuilder:
                 raise KeyError(f'Gate "{op}" not found.')
             angle, qbn = op_name[1:], op_info[1]
             if angle[-1] == 's' and angle[:-1].isnumeric():
+                # Simultaneous virtual Z pulses (ex: Z90s qb1)
                 op_info[0] = 's' + op_info[0]
                 angle = angle[:-1]
             param = None

--- a/pycqed/measurement/waveform_control/circuit_builder.py
+++ b/pycqed/measurement/waveform_control/circuit_builder.py
@@ -220,7 +220,8 @@ class CircuitBuilder:
             if op_name[0] not in ['X', 'Y', 'Z']:
                 raise KeyError(f'Gate "{op}" not found.')
             angle, qbn = op_name[1:], op_info[1]
-            if angle[-1] == 's':
+            if angle[-1] == 's' and angle[:-1].isnumeric():
+                op_info[0] = 's' + op_info[0]
                 angle = angle[:-1]
             param = None
             if angle[0] == ':':  # angle depends on a parameter

--- a/pycqed/measurement/waveform_control/circuit_builder.py
+++ b/pycqed/measurement/waveform_control/circuit_builder.py
@@ -511,8 +511,8 @@ class CircuitBuilder:
             preparation_pulses += [block_end]
             return Block(block_name, preparation_pulses)
 
-    def mux_readout(self, qb_names='all', element_name='RO', **pulse_pars):
-        block_name = "Readout"
+    def mux_readout(self, qb_names='all', element_name='RO', block_name="Readout",
+                    **pulse_pars):
         _, qb_names = self.get_qubits(qb_names)
         ro_pulses = []
         for j, qb_name in enumerate(qb_names):

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -1258,7 +1258,7 @@ class Segment:
                 len(channel_map)
             if axes is not None:
                 if np.ndim(axes) == 0:
-                    axes = [[axes]]
+                    axes = np.array([[axes]])
                 fig = axes[0,0].get_figure()
                 ax = axes
             else:

--- a/pycqed/measurement/waveform_control/segment.py
+++ b/pycqed/measurement/waveform_control/segment.py
@@ -56,6 +56,7 @@ class Segment:
         self._pulse_names = set()
         self.acquisition_elements = set()
         self.timer = Timer(self.name)
+        self.pulse_pars = []
 
         for pulse_pars in pulse_pars_list:
             self.add(pulse_pars)
@@ -66,6 +67,7 @@ class Segment:
         and sets default values where necessary. After that an UnresolvedPulse
         is instantiated.
         """
+        self.pulse_pars.append(deepcopy(pulse_pars))
         pars_copy = deepcopy(pulse_pars)
 
         # Makes sure that pulse name is unique


### PR DESCRIPTION
- CB.sweep_n_dim: do not add counter to block names
- CB: fix bug where cz_pulse_name was used even if a more specific CZ opcode was provided
- CB.get_pulse: deal with simultaneous Z pulses, where an 's' string follows the angle.
- CB.get_qubits: allow getting qubits by their logical indices
- CB: Add possibility to choose name of ro block
- Segment: store raw pulse dicts from which the segment was created
- Segment: Set ax in np.array instead of double list when ax is provided and not an array
- Block.pulses_sweepcopy: make it work even when op dict has no 'op_code' key

From S17.

Inviting @stephlazar to review
FYI @nathlacroix @antsr 