### PR TITLE
T1FrequencySweep: use new voltage_frequence_conversion and allow passing both amps&freqs

### DIFF
--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -110,17 +110,17 @@ class T1FrequencySweep(CalibBuilder):
             if len(sweep_points) == 1:
                 sweep_points.add_sweep_dimension()
             if 'qubit_freqs' in sweep_points[1]:
-                qubit_freqs = sweep_points[1]['qubit_freqs'][0]
+                qubit_freqs = sweep_points['qubit_freqs']
             elif len(self.sweep_points) >= 2 and \
                     'qubit_freqs' in self.sweep_points[1]:
-                qubit_freqs = self.sweep_points[1]['qubit_freqs'][0]
+                qubit_freqs = self.sweep_points['qubit_freqs']
             else:
                 qubit_freqs = None
             if 'amplitude' in sweep_points[1]:
-                amplitudes = sweep_points[1]['amplitude'][0]
+                amplitudes = sweep_points['amplitude']
             elif len(self.sweep_points) >= 2 and \
                     'amplitude' in self.sweep_points[1]:
-                amplitudes = self.sweep_points[1]['amplitude'][0]
+                amplitudes = self.sweep_points['amplitude']
             else:
                 amplitudes = None
             qubits, _ = self.get_qubits(task['qb'])

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -1,15 +1,12 @@
 import numpy as np
-from copy import copy
 from copy import deepcopy
 import traceback
 from pycqed.measurement.calibration.two_qubit_gates import CalibBuilder
 import pycqed.measurement.sweep_functions as swf
-from pycqed.measurement.waveform_control.block import Block, ParametricValue
+from pycqed.measurement.waveform_control.block import ParametricValue
 from pycqed.measurement.waveform_control import segment as seg_mod
 from pycqed.measurement.sweep_points import SweepPoints
-from pycqed.analysis import fitting_models as fit_mods
 import pycqed.analysis_v2.timedomain_analysis as tda
-from pycqed.analysis import measurement_analysis as ma
 from pycqed.utilities.general import temporary_value
 import logging
 

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -1,5 +1,5 @@
 import numpy as np
-from copy import deepcopy
+from copy import copy, deepcopy
 import traceback
 from pycqed.measurement.calibration.two_qubit_gates import CalibBuilder
 import pycqed.measurement.sweep_functions as swf
@@ -70,7 +70,8 @@ class T1FrequencySweep(CalibBuilder):
             self.data_to_fit = {qb: 'pe' for qb in self.meas_obj_names}
             self.sweep_points = SweepPoints(
                 [{}, {}] if self.sweep_points is None else self.sweep_points)
-            self.add_amplitude_sweep_points(**kw)
+            self.task_list = self.add_amplitude_sweep_points(
+                [copy(t) for t in self.task_list], **kw)
 
             self.preprocessed_task_list = self.preprocess_task_list(**kw)
             self.sequences, self.mc_points = \

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -119,8 +119,24 @@ class T1FrequencySweep(CalibBuilder):
                 qubit_freqs = self.sweep_points[1]['qubit_freqs'][0]
             else:
                 qubit_freqs = None
-            if qubit_freqs is not None:
-                qubits, _ = self.get_qubits(task['qb'])
+            if 'amplitude' in sweep_points[1]:
+                amplitudes = sweep_points[1]['amplitude'][0]
+            elif len(self.sweep_points) >= 2 and \
+                    'amplitude' in self.sweep_points[1]:
+                amplitudes = self.sweep_points[1]['amplitude'][0]
+            else:
+                amplitudes = None
+            qubits, _ = self.get_qubits(task['qb'])
+            if qubit_freqs is None and qubits is not None:
+                qb = qubits[0]
+                qubit_freqs = qb.calculate_frequency(
+                    amplitude=amplitudes,
+                    **kw.get('vfc_kwargs', {})
+                )
+                freq_sweep_points = SweepPoints('qubit_freqs', qubit_freqs,
+                                                'Hz', 'Qubit frequency')
+                sweep_points.update([{}] + freq_sweep_points)
+            if amplitudes is None:
                 if qubits is None:
                     raise KeyError('qubit_freqs specified in sweep_points, '
                                    'but no qubit objects available, so that '

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -776,7 +776,6 @@ class Cryoscope(CalibBuilder):
             concatenation of the truncation_lengths array for each pulse,
             defined between 0 and total length of each pulse.
         """
-        from pprint import pprint
         parallel_block_list = []
         for i, task in enumerate(self.preprocessed_task_list):
             sweep_points = task['sweep_points']


### PR DESCRIPTION
- T1FrequencySweep: allow choosing the model used for frequency voltage conversion. (new default: uses the default value of QuDev_transmon.calculate_frequency, i.e., transmon_res can be changed to old default by passing `vfc_kwargs=dict(model='approx')`.)
- T1FrequencySweep: allow passing amps&freqs; calculate freqs if only amps are passed (Passing amps&freqs can be used if the amps to reach the given freqs have been pre-calculated externally.)
- some cleanup in the single_qubit_gates module

Tested at XLD.

Inviting @stephlazar to review.
FYI @nathlacroix @antsr 

