### PR TITLE
write_dict_to_hdf5: small fix for proper saving of lists of lists

### DIFF
--- a/pycqed/measurement/hdf5_data.py
+++ b/pycqed/measurement/hdf5_data.py
@@ -197,7 +197,8 @@ def write_dict_to_hdf5(data_dict: dict, entry_point, overwrite=False):
                 # Lists of a single type, are stored as an hdf5 dset
                 if (all(isinstance(x, elt_type) for x in item) and
                         not isinstance(item[0], dict) and
-                        not isinstance(item, tuple)):
+                        not isinstance(item, tuple) and
+                        not isinstance(item[0], list)):
                     if isinstance(item[0], (int, float,
                                             np.int32, np.int64)):
                         try:


### PR DESCRIPTION
Improves write_dict_to_hdf5 (used whenever we write to an HDF file) to properly handle lists of lists. 

Without the change in this PR, we got the following warning when storing "params_to_prefix" = [ [...], [...] ] from the preprocessed_task_list, which, as a result, was stored as a string.
![image](https://user-images.githubusercontent.com/14844492/126966514-bff6c93e-4109-4d5d-8271-d238e38675d3.png)
![image](https://user-images.githubusercontent.com/14844492/126967191-ac9c8f49-22b9-47cf-bd2c-1e788322bdad.png)

After the fix in this PR:
![image](https://user-images.githubusercontent.com/14844492/126967350-ff6e695b-1dce-418e-8bf7-4e8a1dbe2c4c.png)
