### PR TITLE
Bugfix/mixer calib optimizer

### DIFF
--- a/pycqed/measurement/optimization.py
+++ b/pycqed/measurement/optimization.py
@@ -458,18 +458,15 @@ def neural_network_opt(fun, training_grid, target_values = None,
     if x_init is None:
         x_init = np.zeros(n_features)
         #The data is centered. No values above -1,1 should be encountered
-        bounds=[(-1.,1.) for i in range(n_features)]
+        bounds = [(-1.,1.) for i in range(n_features)]
         res = minimize(estimator_wrapper, x_init, method='Nelder-Mead')
     else:
         print('x_init minimizer:', x_init)
         for it in range(n_features):
             x_init[it] = (x_init[it]-input_feature_means[it])/input_feature_ext[it] # scale initial value
-        bounds=[(-1.,0.5) for i in range(n_features)]
+        bounds = [(-1.,0.5) for i in range(n_features)]
         res = minimize(estimator_wrapper, x_init, method='Nelder-Mead')
-        # res = [res.x]
         print('result:', res)
-        # print(res)
-
 
     result = res.x
     opti_flag = True

--- a/pycqed/measurement/optimization.py
+++ b/pycqed/measurement/optimization.py
@@ -459,22 +459,19 @@ def neural_network_opt(fun, training_grid, target_values = None,
         x_init = np.zeros(n_features)
         #The data is centered. No values above -1,1 should be encountered
         bounds=[(-1.,1.) for i in range(n_features)]
-        res = fmin_l_bfgs_b(estimator_wrapper, x_init, bounds=bounds,
-                            approx_grad=True)
+        res = minimize(estimator_wrapper, x_init, method='Nelder-Mead')
     else:
         print('x_init minimizer:', x_init)
         for it in range(n_features):
             x_init[it] = (x_init[it]-input_feature_means[it])/input_feature_ext[it] # scale initial value
         bounds=[(-1.,0.5) for i in range(n_features)]
-        res = fmin_l_bfgs_b(estimator_wrapper, x_init, approx_grad=True, bounds=bounds)
-        # res = minimize(estimator_wrapper, x_init, method='Nelder-Mead')
+        res = minimize(estimator_wrapper, x_init, method='Nelder-Mead')
         # res = [res.x]
         print('result:', res)
         # print(res)
 
 
-    # result = res.x
-    result = res[0]
+    result = res.x
     opti_flag = True
 
     for it in range(n_features):


### PR DESCRIPTION
Replaces the scipy.optimize.fmin_l_bfgs_b optimizer used in optimization.py/neural_network_opt by scipy.optimize.minimize because the way we called the former is not supported by the latest versions of scipy/numpy.

The change has been successfully used at the BF1 setup for a few months.