### PR TITLE
Bugfix/qe sweep unit + use getter methods

### DIFF
--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -503,7 +503,7 @@ class QuantumExperiment(CircuitBuilder):
 
         try:
             sweep_param_name = list(self.sweep_points[0])[0]
-            unit = list(self.sweep_points[0].values())[0][2]
+            unit = list(self.sweep_points[0].values())[0][1]
         except TypeError:
             sweep_param_name, unit = "None", ""
         sweep_func_1st_dim = self.sweep_functions[0](
@@ -517,7 +517,7 @@ class QuantumExperiment(CircuitBuilder):
         if len(self.mc_points[1]) > 0: # second dimension exists
             try:
                 sweep_param_name = list(self.sweep_points[1])[0]
-                unit = list(self.sweep_points[1].values())[0][2]
+                unit = list(self.sweep_points[1].values())[0][1]
             except TypeError:
                 sweep_param_name, unit = "None", ""
             if len(self.channels_to_upload) == 0:

--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -469,7 +469,8 @@ class QuantumExperiment(CircuitBuilder):
                 self.mc_points[1] = np.arange(len(self.sequences))
             elif self.sweep_points is not None and len(self.sweep_points) > 1:
                 # second dimension can be inferred from sweep points
-                self.mc_points[1] = list(self.sweep_points[1].values())[0][0]
+                self.mc_points[1] = self.sweep_points.get_sweep_params_property(
+                    'values', 1)
             else:
                 raise ValueError("The second dimension of mc_points must be provided "
                                  "if the sweep function isn't 'SegmentSoftSweep' and"
@@ -503,7 +504,8 @@ class QuantumExperiment(CircuitBuilder):
 
         try:
             sweep_param_name = list(self.sweep_points[0])[0]
-            unit = list(self.sweep_points[0].values())[0][1]
+            unit = self.sweep_points.get_sweep_params_property(
+                'unit', 0, param_names=sweep_param_name)
         except TypeError:
             sweep_param_name, unit = "None", ""
         sweep_func_1st_dim = self.sweep_functions[0](
@@ -517,7 +519,8 @@ class QuantumExperiment(CircuitBuilder):
         if len(self.mc_points[1]) > 0: # second dimension exists
             try:
                 sweep_param_name = list(self.sweep_points[1])[0]
-                unit = list(self.sweep_points[1].values())[0][1]
+                unit = self.sweep_points.get_sweep_params_property(
+                    'unit', 1, param_names=sweep_param_name)
             except TypeError:
                 sweep_param_name, unit = "None", ""
             if len(self.channels_to_upload) == 0:


### PR DESCRIPTION
In QuantumExperiment._configure_mc:
- fixes bug that assigned the sweep parameter label to the unit
- changes relevant lines to use the SweepPoints getter methods 

