### PR TITLE
Enh/ro plots

### DIFF
--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -3267,29 +3267,32 @@ class QuDev_transmon(Qubit):
             total_dist = np.abs(trace['e'] - trace['g']) + \
                          np.abs(trace['f'] - trace['g']) + \
                          np.abs(trace['f'] - trace['e'])
-            fmax = freqs[np.argmax(total_dist)]
-            # FIXME: just as debug plotting for now
-            fig, ax = plt.subplots(2)
-            ax[0].plot(freqs, np.abs(trace['g']), label='g')
-            ax[0].plot(freqs, np.abs(trace['e']), label='e')
+        else:
+            total_dist = np.abs(trace['e'] - trace['g'])
+        fmax = freqs[np.argmax(total_dist)]
+        # FIXME: just as debug plotting for now
+        fig, ax = plt.subplots(2)
+        ax[0].plot(freqs, np.abs(trace['g']), label='g')
+        ax[0].plot(freqs, np.abs(trace['e']), label='e')
+        if qutrit:
             ax[0].plot(freqs, np.abs(trace['f']), label='f')
-            ax[0].set_ylabel('Amplitude')
-            ax[0].legend()
-            ax[1].plot(freqs, np.abs(trace['e'] - trace['g']), label='eg')
+        ax[0].set_ylabel('Amplitude')
+        ax[0].legend()
+        ax[1].plot(freqs, np.abs(trace['e'] - trace['g']), label='eg')
+        if qutrit:
             ax[1].plot(freqs, np.abs(trace['f'] - trace['g']), label='fg')
             ax[1].plot(freqs, np.abs(trace['e'] - trace['f']), label='ef')
-            ax[1].plot(freqs, total_dist, label='total distance')
-            ax[1].set_xlabel("Freq. [Hz]")
-            ax[1].set_ylabel('Distance in IQ plane')
-            ax[0].set_title("Current RO_freq: {} Hz\nOptimal Freq: {} Hz".format(
-                self.ro_freq(),
-                                                                          fmax))
-            plt.legend()
+        ax[1].plot(freqs, total_dist, label='total distance')
+        ax[1].set_xlabel("Freq. [Hz]")
+        ax[1].set_ylabel('Distance in IQ plane')
+        ax[0].set_title(f"Current RO_freq: {self.ro_freq()} Hz" + "\n"
+                        + f"Optimal Freq: {fmax} Hz")
+        plt.legend()
 
-            m_a['g'].save_fig(fig, 'IQplane_distance')
-            plt.show()
-            if kw.get('analyze', True):
-                sa.ResonatorSpectroscopy_v2(labels=[l for l in labels.values()])
+        m_a['g'].save_fig(fig, 'IQplane_distance')
+        plt.show()
+        if kw.get('analyze', True):
+            sa.ResonatorSpectroscopy_v2(labels=[l for l in labels.values()])
         else:
             fmax = freqs[np.argmax(np.abs(trace['e'] - trace['g']))]
 

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -3270,7 +3270,7 @@ class QuDev_transmon(Qubit):
         else:
             total_dist = np.abs(trace['e'] - trace['g'])
         fmax = freqs[np.argmax(total_dist)]
-        # FIXME: just as debug plotting for now
+        # Plotting which works for qubit or qutrit
         fig, ax = plt.subplots(2)
         ax[0].plot(freqs, np.abs(trace['g']), label='g')
         ax[0].plot(freqs, np.abs(trace['e']), label='e')
@@ -3288,9 +3288,9 @@ class QuDev_transmon(Qubit):
         ax[0].set_title(f"Current RO_freq: {self.ro_freq()} Hz" + "\n"
                         + f"Optimal Freq: {fmax} Hz")
         plt.legend()
-
+        # Save figure into 'g' measurement folder
         m_a['g'].save_fig(fig, 'IQplane_distance')
-        plt.show()
+
         if kw.get('analyze', True):
             sa.ResonatorSpectroscopy_v2(labels=[l for l in labels.values()])
         else:


### PR DESCRIPTION
Generalize plotting of `measure_dispersive_shift`

This pull request adapts the plotting code in `QuDev_transmon.measure_dispersive_shift` so that it correctly computes the total trace distance and produces output for both qubit and qutrit readout.

The code was tested with qubit readout at BF1 and I believe that qutrit readout worked in a virtual setup.

