### PR TITLE
Raise warning image bug

### DIFF
--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -269,9 +269,10 @@ class BaseDataAnalysis(object):
         :param warning_textfile_name: string with name of the file without
             extension.
         """
-        if not self.check_plotting_delegation():
+        if self.check_plotting_delegation():
+            # Only execute this function if the AnalysisDaemon is not running.
             # The warning image and text file will be generated twice
-            # when the AnalysisDaemon is active
+            # when the AnalysisDaemon is running.
             return
 
         destination_path = a_tools.get_folder(self.timestamps[-1])

--- a/pycqed/analysis_v2/base_analysis.py
+++ b/pycqed/analysis_v2/base_analysis.py
@@ -270,9 +270,9 @@ class BaseDataAnalysis(object):
             extension.
         """
         if self.check_plotting_delegation():
-            # Only execute this function if the AnalysisDaemon is not running.
-            # The warning image and text file will be generated twice
-            # when the AnalysisDaemon is running.
+            # Do not execute this function if plotting is delegated to the
+            # AnalysisDaemon, in order to avoid that the warning image and
+            # text file are generated twice.
             return
 
         destination_path = a_tools.get_folder(self.timestamps[-1])


### PR DESCRIPTION
BaseDataAnalysis._raise_warning: fixes bug related to delegating plotting to AnalysisDaemon.

- the function was skipped if delegate_plotting == False. Now it is fixed to do so if it is True.

Very silly bug. Very quick one-liner to review for @chellings 