### PR TITLE
New Features for Frequency Sweep Measurements to Improve Flux Pulse Scopes

### DIFF
--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5218,7 +5218,7 @@ class RabiFrequencySweepAnalysis(RabiAnalysis):
             ampls = deepcopy(self.proc_data_dict['analysis_params_dict'][
                 'amplitudes'][qbn])
             if len(excl_idxs):
-                mask = np.arange(len(freqs)) == excl_idxs
+                mask = np.array([i in excl_idxs for i in np.arange(len(freqs))])
                 ampls = ampls[np.logical_not(mask)]
                 freqs = freqs[np.logical_not(mask)]
 

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -1388,6 +1388,28 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                     plot_dict_cal = self.plot_dicts.pop(plot_name)
                     self.plot_dicts[plot_name] = plot_dict_cal
 
+    def get_first_sweep_param(self, qbn=None, dimension=0):
+        """
+        Get properties of the first sweep param in the given dimension
+        (potentially for the given qubit).
+        :param qbn: (str) qubit name. If None, all sweep params are considered.
+        :param dimension: (float, default: 0) sweep dimension to be considered.
+        :return: a 3-tuple of label, unit, and array of values
+        """
+        if qbn is None:
+            param_name = [p for v in self.mospm.values() for p in v
+                          if self.sp.find_parameter(p) == 1][0]
+        else:
+            param_name = [p for p in self.mospm[qbn]
+                          if self.sp.find_parameter(p)][0]
+        label = self.sp.get_sweep_params_property(
+            'label', dimension=dimension, param_names=param_name)
+        unit = self.sp.get_sweep_params_property(
+            'unit', dimension=dimension, param_names=param_name)
+        vals = self.sp.get_sweep_params_property(
+            'values', dimension=dimension, param_names=param_name)
+        return label, unit, vals
+
 
 class Idling_Error_Rate_Analyisis(ba.BaseDataAnalysis):
 

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -4878,8 +4878,7 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
 
     def prepare_fitting(self):
         self.fit_dicts = OrderedDict()
-        for qbn in self.qb_names:
-            data = self.proc_data_dict['data_to_fit'][qbn]
+        def add_fit_dict(qbn, data, key):
             sweep_points = self.proc_data_dict['sweep_points_dict'][qbn][
                 'msmt_sweep_points']
             if self.num_cal_points != 0:
@@ -4894,20 +4893,30 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
             guess_pars['phase'].vary = True
             self.set_user_guess_pars(guess_pars)
 
-            key = 'cos_fit_' + qbn
             self.fit_dicts[key] = {
                 'fit_fn': fit_mods.CosFunc,
                 'fit_xvals': {'t': sweep_points},
                 'fit_yvals': {'data': data},
                 'guess_pars': guess_pars}
 
+        for qbn in self.qb_names:
+            all_data = self.proc_data_dict['data_to_fit'][qbn]
+            if self.get_param_value('TwoD'):
+                for i, data in enumerate(all_data):
+                    key = f'cos_fit_{qbn}_{i}'
+                    add_fit_dict(qbn, data, key)
+            else:
+                add_fit_dict(qbn, all_data, 'cos_fit_' + qbn)
+
     def analyze_fit_results(self):
         self.proc_data_dict['analysis_params_dict'] = OrderedDict()
-        for qbn in self.qb_names:
-            fit_res = self.fit_dicts['cos_fit_' + qbn]['fit_res']
+        for k, fit_dict in self.fit_dicts.items():
+            k = k.replace('cos_fit_', '')
+            qbn, i = (k + '_').split('_')[:2]
+            fit_res = fit_dict['fit_res']
             sweep_points = self.proc_data_dict['sweep_points_dict'][qbn][
                 'msmt_sweep_points']
-            self.proc_data_dict['analysis_params_dict'][qbn] = \
+            self.proc_data_dict['analysis_params_dict'][k] = \
                 self.get_amplitudes(fit_res=fit_res, sweep_points=sweep_points)
         self.save_processed_data(key='analysis_params_dict')
 
@@ -5024,16 +5033,21 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
         super().prepare_plots()
 
         if self.do_fitting:
-            for qbn in self.qb_names:
-                base_plot_name = 'Rabi_' + qbn
+            for k, fit_dict in self.fit_dicts.items():
+                k = k.replace('cos_fit_', '')
+                qbn, i = (k + '_').split('_')[:2]
+                fit_res = fit_dict['fit_res']
+                base_plot_name = 'Rabi_' + k
+                dtf = self.proc_data_dict['data_to_fit'][qbn]
                 self.prepare_projected_data_plot(
                     fig_name=base_plot_name,
-                    data=self.proc_data_dict['data_to_fit'][qbn],
+                    data=dtf[int(i)] if i != '' else dtf,
                     plot_name_suffix=qbn+'fit',
-                    qb_name=qbn)
+                    qb_name=qbn, TwoD=False,
+                    title_suffix=i
+                )
 
-                fit_res = self.fit_dicts['cos_fit_' + qbn]['fit_res']
-                self.plot_dicts['fit_' + qbn] = {
+                self.plot_dicts['fit_' + k] = {
                     'fig_id': base_plot_name,
                     'plotfn': self.plot_fit,
                     'fit_res': fit_res,
@@ -5045,12 +5059,12 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                     'legend_pos': 'upper right'}
 
                 rabi_amplitudes = self.proc_data_dict['analysis_params_dict']
-                self.plot_dicts['piamp_marker_' + qbn] = {
+                self.plot_dicts['piamp_marker_' + k] = {
                     'fig_id': base_plot_name,
                     'plotfn': self.plot_line,
-                    'xvals': np.array([rabi_amplitudes[qbn]['piPulse']]),
+                    'xvals': np.array([rabi_amplitudes[k]['piPulse']]),
                     'yvals': np.array([fit_res.model.func(
-                        rabi_amplitudes[qbn]['piPulse'],
+                        rabi_amplitudes[k]['piPulse'],
                         **fit_res.best_values)]),
                     'setlabel': '$\pi$-Pulse amp',
                     'color': 'r',
@@ -5062,11 +5076,11 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                     'legend_bbox_to_anchor': (1, -0.15),
                     'legend_pos': 'upper right'}
 
-                self.plot_dicts['piamp_hline_' + qbn] = {
+                self.plot_dicts['piamp_hline_' + k] = {
                     'fig_id': base_plot_name,
                     'plotfn': self.plot_hlines,
                     'y': [fit_res.model.func(
-                        rabi_amplitudes[qbn]['piPulse'],
+                        rabi_amplitudes[k]['piPulse'],
                         **fit_res.best_values)],
                     'xmin': self.proc_data_dict['sweep_points_dict'][qbn][
                         'sweep_points'][0],
@@ -5074,12 +5088,12 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                         'sweep_points'][-1],
                     'colors': 'gray'}
 
-                self.plot_dicts['pihalfamp_marker_' + qbn] = {
+                self.plot_dicts['pihalfamp_marker_' + k] = {
                     'fig_id': base_plot_name,
                     'plotfn': self.plot_line,
-                    'xvals': np.array([rabi_amplitudes[qbn]['piHalfPulse']]),
+                    'xvals': np.array([rabi_amplitudes[k]['piHalfPulse']]),
                     'yvals': np.array([fit_res.model.func(
-                        rabi_amplitudes[qbn]['piHalfPulse'],
+                        rabi_amplitudes[k]['piHalfPulse'],
                         **fit_res.best_values)]),
                     'setlabel': '$\pi /2$-Pulse amp',
                     'color': 'm',
@@ -5091,11 +5105,11 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                     'legend_bbox_to_anchor': (1, -0.15),
                     'legend_pos': 'upper right'}
 
-                self.plot_dicts['pihalfamp_hline_' + qbn] = {
+                self.plot_dicts['pihalfamp_hline_' + k] = {
                     'fig_id': base_plot_name,
                     'plotfn': self.plot_hlines,
                     'y': [fit_res.model.func(
-                        rabi_amplitudes[qbn]['piHalfPulse'],
+                        rabi_amplitudes[k]['piHalfPulse'],
                         **fit_res.best_values)],
                     'xmin': self.proc_data_dict['sweep_points_dict'][qbn][
                         'sweep_points'][0],
@@ -5115,18 +5129,18 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                 old_pihalfpulse_val *= old_pipulse_val
 
                 textstr = ('  $\pi-Amp$ = {:.3f} V'.format(
-                    rabi_amplitudes[qbn]['piPulse']) +
+                    rabi_amplitudes[k]['piPulse']) +
                            ' $\pm$ {:.3f} V '.format(
-                    rabi_amplitudes[qbn]['piPulse_stderr']) +
+                    rabi_amplitudes[k]['piPulse_stderr']) +
                            '\n$\pi/2-Amp$ = {:.3f} V '.format(
-                    rabi_amplitudes[qbn]['piHalfPulse']) +
+                    rabi_amplitudes[k]['piHalfPulse']) +
                            ' $\pm$ {:.3f} V '.format(
-                    rabi_amplitudes[qbn]['piHalfPulse_stderr']) +
+                    rabi_amplitudes[k]['piHalfPulse_stderr']) +
                            '\n  $\pi-Amp_{old}$ = ' + '{:.3f} V '.format(
                     old_pipulse_val) +
                            '\n$\pi/2-Amp_{old}$ = ' + '{:.3f} V '.format(
                     old_pihalfpulse_val))
-                self.plot_dicts['text_msg_' + qbn] = {
+                self.plot_dicts['text_msg_' + k] = {
                     'fig_id': base_plot_name,
                     'ypos': -0.2,
                     'xpos': 0,

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5070,6 +5070,14 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
 
                 k = k.replace('cos_fit_', '')
                 qbn, i = (k + '_').split('_')[:2]
+                if len(i):
+                    label, unit, vals = self.get_first_sweep_param(
+                        qbn, dimension=1)
+                    title_suffix = (f'{i}: {label} = ' + ' '.join(
+                        SI_val_to_msg_str(vals[int(i)], unit,
+                                          return_type=lambda x : f'{x:0.4f}')))
+                else:
+                    title_suffix = ''
                 fit_res = fit_dict['fit_res']
                 base_plot_name = 'Rabi_' + k
                 dtf = self.proc_data_dict['data_to_fit'][qbn]
@@ -5078,7 +5086,7 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                     data=dtf[int(i)] if i != '' else dtf,
                     plot_name_suffix=qbn+'fit',
                     qb_name=qbn, TwoD=False,
-                    title_suffix=i
+                    title_suffix=title_suffix
                 )
 
                 self.plot_dicts['fit_' + k] = {

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -4861,19 +4861,22 @@ class FluxlineCrosstalkAnalysis(MultiQubit_TimeDomain_Analysis):
                         'color': 'C1',
                     }
 
+
 class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
 
     def __init__(self, qb_names, *args, **kwargs):
-        params_dict = {}
+        params_dict = kwargs.get('params_dict', {})
+        pd = {}
         for qbn in qb_names:
             s = 'Instrument settings.'+qbn
             for trans_name in ['ge', 'ef']:
-                params_dict[f'{trans_name}_amp180_'+qbn] = \
+                pd[f'{trans_name}_amp180_'+qbn] = \
                     s+f'.{trans_name}_amp180'
-                params_dict[f'{trans_name}_amp90scale_'+qbn] = \
+                pd[f'{trans_name}_amp90scale_'+qbn] = \
                     s+f'.{trans_name}_amp90_scale'
+        params_dict.update(pd)
         kwargs['params_dict'] = params_dict
-        kwargs['numeric_params'] = list(params_dict)
+        kwargs['numeric_params'] = list(pd)
         super().__init__(qb_names, *args, **kwargs)
 
     def prepare_fitting(self):
@@ -5023,7 +5026,8 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
 
         return rabi_amplitudes
 
-    def calculate_pulse_stderr(self, f, phi, f_err, phi_err,
+    @staticmethod
+    def calculate_pulse_stderr(f, phi, f_err, phi_err,
                                period_const, cov=0):
         x = period_const + phi
         return np.sqrt((2*np.pi*f_err*x/(2*np.pi*(f**2)))**2 +
@@ -5035,6 +5039,11 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
 
         if self.do_fitting:
             for k, fit_dict in self.fit_dicts.items():
+                if k.startswith('amplitude_fit'):
+                    # This is only for RabiFrequencySweepAnalysis.
+                    # It is handled by prepare_amplitude_fit_plots of that class
+                    continue
+
                 k = k.replace('cos_fit_', '')
                 qbn, i = (k + '_').split('_')[:2]
                 fit_res = fit_dict['fit_res']
@@ -5149,6 +5158,196 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                     'verticalalignment': 'top',
                     'plotfn': self.plot_text,
                     'text_string': textstr}
+
+
+class RabiFrequencySweepAnalysis(RabiAnalysis):
+
+    def __init__(self, qb_names, *args, **kwargs):
+        params_dict = kwargs.get('params_dict', {})
+        for qbn in qb_names:
+            params_dict[f'drive_ch_{qbn}'] = \
+                f'Instrument settings.{qbn}.ge_I_channel'
+            params_dict[f'ge_freq_{qbn}'] = \
+                f'Instrument settings.{qbn}.ge_freq'
+        kwargs['params_dict'] = params_dict
+        super().__init__(qb_names, *args, **kwargs)
+
+    def analyze_fit_results(self):
+        super().analyze_fit_results()
+        amplitudes = {qbn: np.array([[
+            self.proc_data_dict[
+                'analysis_params_dict'][f'{qbn}_{i}']['piPulse'],
+            self.proc_data_dict[
+                'analysis_params_dict'][f'{qbn}_{i}']['piPulse_stderr']]
+            for i in range(self.sp.length(1))]) for qbn in self.qb_names}
+        self.proc_data_dict['analysis_params_dict']['amplitudes'] = amplitudes
+
+        fit_dict_keys = self.prepare_fitting_pulse_amps()
+        self.run_fitting(keys_to_fit=fit_dict_keys)
+
+        lo_freqsX = self.get_param_value('allowed_lo_freqs')
+        mid_freq = np.mean(lo_freqsX)
+        self.proc_data_dict['analysis_params_dict']['rabi_model_lo'] = {}
+        func_repr = lambda a, b, c: \
+            f'{a} * (x / 1e9) ** 2 + {b} * x/ 1e9 + {c}'
+        for qbn in self.qb_names:
+            drive_ch = self.raw_data_dict[f'drive_ch_{qbn}']
+            pd = self.get_data_from_timestamp_list({
+                f'ch_amp': f'Instrument settings.Pulsar.{drive_ch}_amp'})
+            fit_res_L = self.fit_dicts[f'amplitude_fit_left_{qbn}']['fit_res']
+            fit_res_R = self.fit_dicts[f'amplitude_fit_right_{qbn}']['fit_res']
+            rabi_model_lo = \
+                f'lambda x : np.minimum({pd["ch_amp"]}, ' \
+                f'({func_repr(**fit_res_R.best_values)}) * (x >= {mid_freq})' \
+                f'+ ({func_repr(**fit_res_L.best_values)}) * (x < {mid_freq}))'
+            self.proc_data_dict['analysis_params_dict']['rabi_model_lo'][
+                qbn] = rabi_model_lo
+
+    def prepare_fitting_pulse_amps(self):
+        exclude_freq_indices = self.get_param_value('exclude_freq_indices', {})
+        # TODO: generalize the code for len(allowed_lo_freqs) > 2
+        lo_freqsX = self.get_param_value('allowed_lo_freqs')
+        if lo_freqsX is None:
+            raise ValueError('allowed_lo_freqs not found.')
+        fit_dict_keys = []
+        self.proc_data_dict['analysis_params_dict']['optimal_vals'] = {}
+        for i, qbn in enumerate(self.qb_names):
+            excl_idxs = exclude_freq_indices.get(qbn, [])
+            param = [p for p in self.mospm[qbn] if 'freq' in p][0]
+            freqs = self.sp.get_sweep_params_property('values', 1, param)
+            ampls = deepcopy(self.proc_data_dict['analysis_params_dict'][
+                'amplitudes'][qbn])
+            if len(excl_idxs):
+                mask = np.arange(len(freqs)) == excl_idxs
+                ampls = ampls[np.logical_not(mask)]
+                freqs = freqs[np.logical_not(mask)]
+
+            optimal_idx = np.argmin(np.abs(
+                freqs - self.raw_data_dict[f'ge_freq_{qbn}']))
+            self.proc_data_dict['analysis_params_dict']['optimal_vals'][qbn] = \
+                (freqs[optimal_idx], ampls[optimal_idx, 0], ampls[optimal_idx, 1])
+
+            mid_freq = np.mean(lo_freqsX)
+            fit_func = lambda x, a, b, c: a * x ** 2 + b * x + c
+
+            # fit left range
+            model = lmfit.Model(fit_func)
+            guess_pars = model.make_params(a=1, b=1, c=0)
+            self.fit_dicts[f'amplitude_fit_left_{qbn}'] = {
+                'fit_fn': fit_func,
+                'fit_xvals': {'x': freqs[freqs < mid_freq]/1e9},
+                'fit_yvals': {'data': ampls[freqs < mid_freq, 0]},
+                'fit_yvals_stderr': ampls[freqs < mid_freq, 1],
+                'guess_pars': guess_pars}
+
+            # fit right range
+            model = lmfit.Model(fit_func)
+            guess_pars = model.make_params(a=1, b=1, c=0)
+            self.fit_dicts[f'amplitude_fit_right_{qbn}'] = {
+                'fit_fn': fit_func,
+                'fit_xvals': {'x': freqs[freqs >= mid_freq]/1e9},
+                'fit_yvals': {'data': ampls[freqs >= mid_freq, 0]},
+                'fit_yvals_stderr': ampls[freqs >= mid_freq, 1],
+                'guess_pars': guess_pars}
+
+            fit_dict_keys += [f'amplitude_fit_left_{qbn}',
+                              f'amplitude_fit_right_{qbn}']
+        return fit_dict_keys
+
+    def prepare_plots(self):
+        super().prepare_plots()
+        if self.do_fitting:
+            for qbn in self.qb_names:
+                base_plot_name = f'Rabi_amplitudes_{qbn}'
+                title = f'{self.raw_data_dict["timestamp"]} ' \
+                        f'{self.raw_data_dict["measurementstring"]}\n{qbn}'
+                plotsize = self.get_default_plot_params(set=False)['figure.figsize']
+                plotsize = (plotsize[0], plotsize[0]/1.25)
+                param = [p for p in self.mospm[qbn] if 'freq' in p][0]
+                xlabel = self.sp.get_sweep_params_property('label', 1, param)
+                xunit = self.sp.get_sweep_params_property('unit', 1, param)
+                lo_freqsX = self.get_param_value('allowed_lo_freqs')
+
+                # plot upper sideband
+                fit_dict = self.fit_dicts[f'amplitude_fit_left_{qbn}']
+                fit_res = fit_dict['fit_res']
+                xmin = min(fit_dict['fit_xvals']['x'])
+                self.plot_dicts[f'{base_plot_name}_left_data'] = {
+                    'plotfn': self.plot_line,
+                    'fig_id': base_plot_name,
+                    'plotsize': plotsize,
+                    'xvals': fit_dict['fit_xvals']['x'],
+                    'xlabel': xlabel,
+                    'xunit': xunit,
+                    'yvals': fit_dict['fit_yvals']['data'],
+                    'ylabel': '$\\pi$-pulse amplitude, $A$',
+                    'yunit': 'V',
+                    'setlabel': f'LSB, LO at {np.max(lo_freqsX)/1e9:.3f} GHz',
+                    'title': title,
+                    'linestyle': 'none',
+                    'do_legend': False,
+                    'legend_bbox_to_anchor': (1, 0.5),
+                    'legend_pos': 'center left',
+                    'yerr':  fit_dict['fit_yvals_stderr'],
+                    'color': 'C0'
+                }
+
+                self.plot_dicts[f'{base_plot_name}_left_fit'] = {
+                    'fig_id': base_plot_name,
+                    'plotfn': self.plot_fit,
+                    'fit_res': fit_res,
+                    'setlabel': 'LSB quadratic fit',
+                    'color': 'C0',
+                    'do_legend': True,
+                    # 'legend_ncol': 2,
+                    'legend_bbox_to_anchor': (1, -0.15),
+                    'legend_pos': 'upper right'}
+
+                # plot upper sideband
+                fit_dict = self.fit_dicts[f'amplitude_fit_right_{qbn}']
+                fit_res = fit_dict['fit_res']
+                xmax = max(fit_dict['fit_xvals']['x'])
+                self.plot_dicts[f'{base_plot_name}_right_data'] = {
+                    'plotfn': self.plot_line,
+                    'fig_id': base_plot_name,
+                    'xvals': fit_dict['fit_xvals']['x'],
+                    'xlabel': xlabel,
+                    'xunit': xunit,
+                    'yvals': fit_dict['fit_yvals']['data'],
+                    'ylabel': '$\\pi$-pulse amplitude, $A$',
+                    'yunit': 'V',
+                    'setlabel': f'USB, LO at {np.min(lo_freqsX)/1e9:.3f} GHz',
+                    'title': title,
+                    'linestyle': 'none',
+                    'do_legend': False,
+                    'legend_bbox_to_anchor': (1, 0.5),
+                    'legend_pos': 'center left',
+                    'yerr':  fit_dict['fit_yvals_stderr'],
+                    'color': 'C1'
+                }
+
+                self.plot_dicts[f'{base_plot_name}_right_fit'] = {
+                    'fig_id': base_plot_name,
+                    'plotfn': self.plot_fit,
+                    'fit_res': fit_res,
+                    'setlabel': 'USB quadratic fit',
+                    'color': 'C1',
+                    'do_legend': True,
+                    'legend_ncol': 2,
+                    'legend_bbox_to_anchor': (1, -0.15),
+                    'legend_pos': 'upper right'}
+
+                # max ch amp line
+                drive_ch = self.raw_data_dict[f'drive_ch_{qbn}']
+                pd = self.get_data_from_timestamp_list({
+                    f'ch_amp': f'Instrument settings.Pulsar.{drive_ch}_amp'})
+                self.plot_dicts[f'ch_amp_line_{qbn}'] = {
+                    'fig_id': base_plot_name,
+                    'plotfn': self.plot_hlines,
+                    'y': pd['ch_amp'],
+                    'xmin': xmax,
+                    'xmax': xmin,
+                    'colors': 'k'}
 
 
 class T1Analysis(MultiQubit_TimeDomain_Analysis):

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5062,7 +5062,7 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                                period_const, cov=0):
         jacobian = np.array([-1 / (2 * np.pi * f),
                              - (period_const - phi) / (2 * np.pi * f**2)])
-        cov_matrix = np.array([[phi_err**2, cov**2], [cov**2, f_err**2]])
+        cov_matrix = np.array([[phi_err**2, cov], [cov, f_err**2]])
         return np.sqrt(jacobian @ cov_matrix @ jacobian.T)
 
     def prepare_plots(self):

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -4882,10 +4882,12 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
     def prepare_fitting(self):
         self.fit_dicts = OrderedDict()
         def add_fit_dict(qbn, data, key):
-            sweep_points = self.proc_data_dict['sweep_points_dict'][qbn][
-                'msmt_sweep_points']
             if self.num_cal_points != 0:
                 data = data[:-self.num_cal_points]
+            reduction_arr = np.invert(np.isnan(data))
+            data = data[reduction_arr]
+            sweep_points = self.proc_data_dict['sweep_points_dict'][qbn][
+                'msmt_sweep_points'][reduction_arr]
             cos_mod = lmfit.Model(fit_mods.CosFunc)
             guess_pars = fit_mods.Cos_guess(
                 model=cos_mod, t=sweep_points, data=data)

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -1393,6 +1393,9 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
         :param dimension: (float, default: 0) sweep dimension to be considered.
         :return: a 3-tuple of label, unit, and array of values
         """
+        if not hasattr(self, 'mospm'):
+            return None
+
         if qbn is None:
             param_name = [p for v in self.mospm.values() for p in v
                           if self.sp.find_parameter(p) == 1]

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5323,7 +5323,7 @@ class RabiFrequencySweepAnalysis(RabiAnalysis):
                     'yvals': fit_dict['fit_yvals']['data'],
                     'ylabel': '$\\pi$-pulse amplitude, $A$',
                     'yunit': 'V',
-                    'setlabel': f'LSB, LO at {np.max(lo_freqsX)/1e9:.3f} GHz',
+                    'setlabel': f'USB, LO at {np.min(lo_freqsX)/1e9:.3f} GHz',
                     'title': title,
                     'linestyle': 'none',
                     'do_legend': False,
@@ -5337,14 +5337,14 @@ class RabiFrequencySweepAnalysis(RabiAnalysis):
                     'fig_id': base_plot_name,
                     'plotfn': self.plot_fit,
                     'fit_res': fit_res,
-                    'setlabel': 'LSB quadratic fit',
+                    'setlabel': 'USB quadratic fit',
                     'color': 'C0',
                     'do_legend': True,
                     # 'legend_ncol': 2,
                     'legend_bbox_to_anchor': (1, -0.15),
                     'legend_pos': 'upper right'}
 
-                # plot upper sideband
+                # plot lower sideband
                 fit_dict = self.fit_dicts[f'amplitude_fit_right_{qbn}']
                 fit_res = fit_dict['fit_res']
                 xmax = max(fit_dict['fit_xvals']['x'])
@@ -5357,7 +5357,7 @@ class RabiFrequencySweepAnalysis(RabiAnalysis):
                     'yvals': fit_dict['fit_yvals']['data'],
                     'ylabel': '$\\pi$-pulse amplitude, $A$',
                     'yunit': 'V',
-                    'setlabel': f'USB, LO at {np.min(lo_freqsX)/1e9:.3f} GHz',
+                    'setlabel': f'LSB, LO at {np.max(lo_freqsX)/1e9:.3f} GHz',
                     'title': title,
                     'linestyle': 'none',
                     'do_legend': False,
@@ -5371,7 +5371,7 @@ class RabiFrequencySweepAnalysis(RabiAnalysis):
                     'fig_id': base_plot_name,
                     'plotfn': self.plot_fit,
                     'fit_res': fit_res,
-                    'setlabel': 'USB quadratic fit',
+                    'setlabel': 'LSB quadratic fit',
                     'color': 'C1',
                     'do_legend': True,
                     'legend_ncol': 2,

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5204,6 +5204,15 @@ class RabiFrequencySweepAnalysis(RabiAnalysis):
         kwargs['params_dict'] = params_dict
         super().__init__(qb_names, *args, **kwargs)
 
+    def extract_data(self):
+        super().extract_data()
+        # Set some default values specific to RabiFrequencySweepAnalysis if the
+        # respective options have not been set by the user or in the metadata.
+        # (We do not do this in the init since we have to wait until
+        # metadata has been extracted.)
+        if self.get_param_value('TwoD', default_value=None) is None:
+            self.options_dict['TwoD'] = True
+
     def analyze_fit_results(self):
         super().analyze_fit_results()
         amplitudes = {qbn: np.array([[

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -1262,7 +1262,7 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
             self, fig_name, data, qb_name, title_suffix='', sweep_points=None,
             plot_cal_points=True, plot_name_suffix='', fig_name_suffix='',
             data_label='Data', data_axis_label='', do_legend_data=True,
-            do_legend_cal_states=True):
+            do_legend_cal_states=True, TwoD=None):
 
         if len(fig_name_suffix):
             fig_name = f'{fig_name}_{fig_name_suffix}'
@@ -1326,7 +1326,9 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
         plot_dict_name = f'{fig_name}_{plot_name_suffix}'
         xlabel, xunit = self.get_xaxis_label_unit(qb_name)
 
-        if self.get_param_value('TwoD', default_value=False):
+        if TwoD is None:
+            TwoD = self.get_param_value('TwoD', default_value=False)
+        if TwoD:
             if self.sp is None:
                 soft_sweep_params = self.get_param_value(
                     'soft_sweep_params')

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -4944,7 +4944,7 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
         if freq_fit > 2 * stepsize:
             log.info('The data could not be fitted correctly. The '
                          'frequency "%s" is too high.' % freq_fit)
-        n = np.arange(-2, 10)
+        n = np.arange(-10, 10)
 
         piPulse_vals = (n*np.pi - phase_fit)/(2*np.pi*freq_fit)
         piHalfPulse_vals = (n*np.pi + np.pi/2 - phase_fit)/(2*np.pi*freq_fit)
@@ -4952,8 +4952,8 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
         # find piHalfPulse
         try:
             piHalfPulse = \
-                np.min(piHalfPulse_vals[piHalfPulse_vals >= sweep_points[1]])
-            n_piHalf_pulse = n[piHalfPulse_vals==piHalfPulse]
+                np.min(piHalfPulse_vals[piHalfPulse_vals >= sweep_points[0]])
+            n_piHalf_pulse = n[piHalfPulse_vals==piHalfPulse][0]
         except ValueError:
             piHalfPulse = np.asarray([])
 
@@ -4972,7 +4972,7 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                     np.min(piPulse_vals[piPulse_vals >= piHalfPulse])
             else:
                 piPulse = np.min(piPulse_vals[piPulse_vals >= 0.001])
-            n_pi_pulse = n[piHalfPulse_vals == piHalfPulse]
+            n_pi_pulse = n[piHalfPulse_vals == piHalfPulse][0]
 
         except ValueError:
             piPulse = np.asarray([])
@@ -5001,17 +5001,18 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                 phi=phase_fit,
                 f_err=freq_std,
                 phi_err=phase_std,
-                period_num=n_pi_pulse,
+                period_const=n_pi_pulse*np.pi,
                 cov=cov_freq_phase)
             piHalfPulse_std = self.calculate_pulse_stderr(
                 f=freq_fit,
                 phi=phase_fit,
                 f_err=freq_std,
                 phi_err=phase_std,
-                period_num=n_piHalf_pulse,
+                period_const=n_piHalf_pulse*np.pi + np.pi/2,
                 cov=cov_freq_phase)
         except Exception as e:
-            log.error(e)
+            log.error(f'{e}\nSome stderrs from fit are None, setting stderr '
+                      f'of pi and pi/2 pulses to 0!')
             piPulse_std = 0
             piHalfPulse_std = 0
 
@@ -5023,11 +5024,11 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
         return rabi_amplitudes
 
     def calculate_pulse_stderr(self, f, phi, f_err, phi_err,
-                               period_num, cov=0):
-        x = period_num + phi
-        return np.sqrt((f_err*x/(2*np.pi*(f**2)))**2 +
+                               period_const, cov=0):
+        x = period_const + phi
+        return np.sqrt((2*np.pi*f_err*x/(2*np.pi*(f**2)))**2 +
                        (phi_err/(2*np.pi*f))**2 -
-                       2*(cov**2)*x/((2*np.pi*(f**3))**2))[0]
+                       2*(cov**2)*x/(4*(np.pi**2)*(f**3)))
 
     def prepare_plots(self):
         super().prepare_plots()

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -1395,10 +1395,14 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
         """
         if qbn is None:
             param_name = [p for v in self.mospm.values() for p in v
-                          if self.sp.find_parameter(p) == 1][0]
+                          if self.sp.find_parameter(p) == 1]
         else:
             param_name = [p for p in self.mospm[qbn]
-                          if self.sp.find_parameter(p)][0]
+                          if self.sp.find_parameter(p)]
+        if not len(param_name):
+            return None
+
+        param_name = param_name[0]
         label = self.sp.get_sweep_params_property(
             'label', dimension=dimension, param_names=param_name)
         unit = self.sp.get_sweep_params_property(
@@ -5072,9 +5076,11 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                 qbn, i = (k + '_').split('_')[:2]
                 sweep_points = self.proc_data_dict['sweep_points_dict'][qbn][
                         'sweep_points']
-                if len(i):
-                    label, unit, vals = self.get_first_sweep_param(
-                        qbn, dimension=1)
+                first_sweep_param = self.get_first_sweep_param(
+                    qbn, dimension=1)
+                if len(i) and first_sweep_param is not None:
+                    # TwoD
+                    label, unit, vals = first_sweep_param
                     title_suffix = (f'{i}: {label} = ' + ' '.join(
                         SI_val_to_msg_str(vals[int(i)], unit,
                                           return_type=lambda x : f'{x:0.4f}')))
@@ -5083,6 +5089,7 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                     if daa is not None:
                         sweep_points = sweep_points * daa[int(i)]
                 else:
+                    # OneD
                     title_suffix = ''
                 fit_res = fit_dict['fit_res']
                 base_plot_name = 'Rabi_' + k

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -1293,8 +1293,7 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                     'fig_id': fig_name,
                     'plotfn': self.plot_line,
                     'plotsize': plotsize,
-                    'xvals': self.proc_data_dict['sweep_points_dict'][qb_name][
-                        'cal_points_sweep_points'][cal_pts_idxs],
+                    'xvals': sweep_points[cal_pts_idxs],
                     'yvals': data[cal_pts_idxs],
                     'setlabel': list(self.cal_states_dict)[i],
                     'do_legend': do_legend_cal_states,
@@ -1309,10 +1308,8 @@ class MultiQubit_TimeDomain_Analysis(ba.BaseDataAnalysis):
                     'plotsize': plotsize,
                     'plotfn': self.plot_hlines,
                     'y': np.mean(data[cal_pts_idxs]),
-                    'xmin': self.proc_data_dict['sweep_points_dict'][qb_name][
-                        'sweep_points'][0],
-                    'xmax': self.proc_data_dict['sweep_points_dict'][qb_name][
-                        'sweep_points'][-1],
+                    'xmin': sweep_points[0],
+                    'xmax': sweep_points[-1],
                     'colors': 'gray'}
 
         else:

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -5060,10 +5060,10 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
     @staticmethod
     def calculate_pulse_stderr(f, phi, f_err, phi_err,
                                period_const, cov=0):
-        x = period_const + phi
-        return np.sqrt((2*np.pi*f_err*x/(2*np.pi*(f**2)))**2 +
-                       (phi_err/(2*np.pi*f))**2 -
-                       2*(cov**2)*x/(4*(np.pi**2)*(f**3)))
+        jacobian = np.array([-1 / (2 * np.pi * f),
+                             - (period_const - phi) / (2 * np.pi * f**2)])
+        cov_matrix = np.array([[phi_err**2, cov**2], [cov**2, f_err**2]])
+        return np.sqrt(jacobian @ cov_matrix @ jacobian.T)
 
     def prepare_plots(self):
         super().prepare_plots()

--- a/pycqed/analysis_v2/timedomain_analysis.py
+++ b/pycqed/analysis_v2/timedomain_analysis.py
@@ -4900,13 +4900,13 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
 
     def prepare_fitting(self):
         self.fit_dicts = OrderedDict()
-        def add_fit_dict(qbn, data, key):
+        def add_fit_dict(qbn, data, key, scalex=1):
             if self.num_cal_points != 0:
                 data = data[:-self.num_cal_points]
             reduction_arr = np.invert(np.isnan(data))
             data = data[reduction_arr]
             sweep_points = self.proc_data_dict['sweep_points_dict'][qbn][
-                'msmt_sweep_points'][reduction_arr]
+                'msmt_sweep_points'][reduction_arr] * scalex
             cos_mod = lmfit.Model(fit_mods.CosFunc)
             guess_pars = fit_mods.Cos_guess(
                 model=cos_mod, t=sweep_points, data=data)
@@ -4926,9 +4926,12 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
         for qbn in self.qb_names:
             all_data = self.proc_data_dict['data_to_fit'][qbn]
             if self.get_param_value('TwoD'):
+                daa = self.metadata.get('drive_amp_adaptation', {}).get(
+                    qbn, None)
                 for i, data in enumerate(all_data):
                     key = f'cos_fit_{qbn}_{i}'
-                    add_fit_dict(qbn, data, key)
+                    add_fit_dict(qbn, data, key,
+                                 scalex=1 if daa is None else daa[i])
             else:
                 add_fit_dict(qbn, all_data, 'cos_fit_' + qbn)
 
@@ -5067,12 +5070,18 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
 
                 k = k.replace('cos_fit_', '')
                 qbn, i = (k + '_').split('_')[:2]
+                sweep_points = self.proc_data_dict['sweep_points_dict'][qbn][
+                        'sweep_points']
                 if len(i):
                     label, unit, vals = self.get_first_sweep_param(
                         qbn, dimension=1)
                     title_suffix = (f'{i}: {label} = ' + ' '.join(
                         SI_val_to_msg_str(vals[int(i)], unit,
                                           return_type=lambda x : f'{x:0.4f}')))
+                    daa = self.metadata.get('drive_amp_adaptation', {}).get(
+                        qbn, None)
+                    if daa is not None:
+                        sweep_points = sweep_points * daa[int(i)]
                 else:
                     title_suffix = ''
                 fit_res = fit_dict['fit_res']
@@ -5081,6 +5090,7 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                 self.prepare_projected_data_plot(
                     fig_name=base_plot_name,
                     data=dtf[int(i)] if i != '' else dtf,
+                    sweep_points=sweep_points,
                     plot_name_suffix=qbn+'fit',
                     qb_name=qbn, TwoD=False,
                     title_suffix=title_suffix
@@ -5121,10 +5131,8 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                     'y': [fit_res.model.func(
                         rabi_amplitudes[k]['piPulse'],
                         **fit_res.best_values)],
-                    'xmin': self.proc_data_dict['sweep_points_dict'][qbn][
-                        'sweep_points'][0],
-                    'xmax': self.proc_data_dict['sweep_points_dict'][qbn][
-                        'sweep_points'][-1],
+                    'xmin': sweep_points[0],
+                    'xmax': sweep_points[-1],
                     'colors': 'gray'}
 
                 self.plot_dicts['pihalfamp_marker_' + k] = {
@@ -5150,10 +5158,8 @@ class RabiAnalysis(MultiQubit_TimeDomain_Analysis):
                     'y': [fit_res.model.func(
                         rabi_amplitudes[k]['piHalfPulse'],
                         **fit_res.best_values)],
-                    'xmin': self.proc_data_dict['sweep_points_dict'][qbn][
-                        'sweep_points'][0],
-                    'xmax': self.proc_data_dict['sweep_points_dict'][qbn][
-                        'sweep_points'][-1],
+                    'xmin': sweep_points[0],
+                    'xmax': sweep_points[-1],
                     'colors': 'gray'}
 
                 trans_name = 'ef' if 'f' in self.data_to_fit[qbn] else 'ge'

--- a/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
+++ b/pycqed/instrument_drivers/meta_instrument/qubit_objects/QuDev_transmon.py
@@ -270,6 +270,11 @@ class QuDev_transmon(Qubit):
                                  'calculate a pi pulse amplitude for a given '
                                  'ge transition frequency.',
                            initial_value=None, parameter_class=ManualParameter)
+        self.add_parameter('fit_ro_freq_over_ge_freq',
+                           label='String representation of function to '
+                                 'calculate a RO frequency for a given '
+                                 'ge transition frequency.',
+                           initial_value=None, parameter_class=ManualParameter)
         self.add_parameter('flux_amplitude_bias_ratio',
                            label='Ratio between a flux pulse amplitude '
                                  'and a DC offset change that lead to '
@@ -461,6 +466,23 @@ class QuDev_transmon(Qubit):
                         f'fit_ge_amp180_over_ge_freq is None.')
             return None
         return eval(amp_func)(ge_freq)
+
+    def get_ro_freq_from_ge_freq(self, ge_freq):
+        """
+        Calculates the RO frequency required for a given ge transition
+        frequency using the function stored in the parameter
+        fit_ro_freq_over_ge_freq. If this parameter is None, the method
+        returns None.
+
+        :param ge_freq: ge transition frequency or an array of frequencies
+        :return: RO frequency or an array of frequencies (or None)
+        """
+        freq_func = self.fit_ro_freq_over_ge_freq()
+        if freq_func is None:
+            log.warning(f'Cannot calculate RO freq for {self.name} since '
+                        f'fit_ro_freq_over_ge_freq is None.')
+            return None
+        return eval(freq_func)(ge_freq)
 
     def calculate_frequency(self, bias=None, amplitude=0, transition='ge',
                             model='transmon_res', flux=None, update=False):

--- a/pycqed/measurement/calibration/calibration_points.py
+++ b/pycqed/measurement/calibration/calibration_points.py
@@ -19,11 +19,18 @@ class CalibrationPoints:
         self.states = states
         default_map = dict(g=['I '], e=["X180 "], f=['X180 ', "X180_ef "])
         self.pulse_label_map = kwargs.get("pulse_label_map", default_map)
+        self.pulse_modifs = kwargs.get('pulse_modifs', None)
 
-    def create_segments(self, operation_dict, pulse_modifs=dict(),
+    def create_segments(self, operation_dict, pulse_modifs=None,
                         segment_prefix='calibration_',
                         **prep_params):
         segments = []
+        if pulse_modifs is None:
+            pulse_modifs = dict()
+        if self.pulse_modifs is not None:
+            pm = deepcopy(self.pulse_modifs)
+            pm.update(pulse_modifs)
+            pulse_modifs = pm
 
         for i, seg_states in enumerate(self.states):
             pulse_list = []

--- a/pycqed/measurement/calibration/calibration_points.py
+++ b/pycqed/measurement/calibration/calibration_points.py
@@ -47,7 +47,9 @@ class CalibrationPoints:
                     if k == 0:
                         pulse['ref_pulse'] = 'segment_start'
                     if len(pulse_modifs) > 0:
-                        pulse = sweep_pulse_params([pulse], pulse_modifs)[0][0]
+                        pulse = sweep_pulse_params(
+                            [pulse], pulse_modifs,
+                            pulse_not_found_warning=False)[0][0]
                         # reset the name as sweep_pulse_params deletes it
                         pulse['name'] = f"{seg_states[j]}_{pulse_name + qbn}_" \
                                         f"{cal_pt_idx}"

--- a/pycqed/measurement/calibration/calibration_points.py
+++ b/pycqed/measurement/calibration/calibration_points.py
@@ -47,6 +47,9 @@ class CalibrationPoints:
                     if k == 0:
                         pulse['ref_pulse'] = 'segment_start'
                     if len(pulse_modifs) > 0:
+                        # The pulse(s) to which the pulse_modifs refer might
+                        # not be present in all calibration segments. We
+                        # thus disable the pulse_not_found_warning.
                         pulse = sweep_pulse_params(
                             [pulse], pulse_modifs,
                             pulse_not_found_warning=False)[0][0]

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -460,12 +460,8 @@ class ParallelLOSweepExperiment(CalibBuilder):
             if 'fluxline' not in task:
                 continue
             qb = self.get_qubits(task['qb'])[0][0]
-            # offs = self.lo_offsets[[lo for lo, qbs in self.lo_qubits.items()
-            #                         if qb in qbs][0]]
-            dc_amp = (
-                lambda x, o=self.qb_offsets[qb],
-                       vfc=qb.fit_ge_freq_from_dc_offset() :
-                fit_mods.Qubit_freq_to_dac_res(np.array([x + o]), **vfc)[0])
+            dc_amp = (lambda x, o=self.qb_offsets[qb], qb=qb:
+                      qb.calculate_flux_voltage(x + o))
             sweep_functions += [swf.Transformed_Sweep(
                 task['fluxline'], transformation=dc_amp,
                 name=f'DC Offset {qb.name}',

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -215,7 +215,8 @@ class T1FrequencySweep(CalibBuilder):
 
 
 class ParallelLOSweepExperiment(CalibBuilder):
-    def __init__(self, task_list, sweep_points=None, **kw):
+    def __init__(self, task_list, sweep_points=None, allowed_lo_freqs=None,
+                 **kw):
         for task in task_list:
             if not isinstance(task['qb'], str):
                 task['qb'] = task['qb'].name
@@ -224,7 +225,9 @@ class ParallelLOSweepExperiment(CalibBuilder):
 
         super().__init__(task_list, sweep_points=sweep_points, **kw)
         self.lo_offsets = {}
+        self.lo_qubits = {}
         self.lo_sweep_points = []
+        self.allowed_lo_freqs = allowed_lo_freqs
         self.analysis = {}
 
         self.preprocessed_task_list = self.preprocess_task_list(**kw)
@@ -249,27 +252,62 @@ class ParallelLOSweepExperiment(CalibBuilder):
                         'without checking for ge_mod_freq corrections.')
         else:
             temp_vals = []
+            f_start = {}
             for task in self.task_list:
                 qb = self.get_qubits(task['qb'])[0][0]
                 sp = self.exp_metadata['meas_obj_sweep_points_map'][qb.name]
                 freq_sp = [s for s in sp if s.endswith(freq_sp_suffix)][0]
-                f_start = self.sweep_points.get_sweep_params_property(
+                f_start[qb] = self.sweep_points.get_sweep_params_property(
                     'values', 1, freq_sp)[0]
                 lo = qb.instr_ge_lo.get_instr()
-                if lo not in self.lo_offsets:
-                    self.lo_offsets[lo] = f_start - qb.ge_mod_freq()
+                if lo not in self.lo_qubits:
+                    self.lo_qubits[lo] = [qb]
                 else:
+                    self.lo_qubits[lo] += [qb]
+
+            for lo, qbs in self.lo_qubits.items():
+                for qb in qbs:
+                    if lo not in self.lo_offsets:
+                        if kw.get('optimize_mod_freqs', False):
+                            fs = [f_start[qb] for qb in self.lo_qubits[lo]]
+                            self.lo_offsets[lo] = 1 / 2 * (max(fs) + min(fs))
+                        else:
+                            self.lo_offsets[lo] = f_start[qb] \
+                                                  - qb.ge_mod_freq()
                     temp_vals.append(
-                        (qb.ge_mod_freq, f_start - self.lo_offsets[lo]))
+                        (qb.ge_mod_freq, f_start[qb] - self.lo_offsets[lo]))
 
             with temporary_value(*temp_vals):
                 self.update_operation_dict()
+
+        if self.allowed_lo_freqs is not None:
+            for task in self.preprocessed_task_list:
+                task['pulse_modifs'] = {'attr=mod_frequency': None}
 
     def run_measurement(self, **kw):
         name = 'Drive frequency shift'
         sweep_functions = [swf.Offset_Sweep(
             lo.frequency, offset, name=name, parameter_name=name, unit='Hz')
             for lo, offset in self.lo_offsets.items()]
+        if self.allowed_lo_freqs is not None:
+            minor_sweep_functions = []
+            for lo, qbs in self.lo_qubits.items():
+                qb_sweep_functions = []
+                for qb in qbs:
+                    mod_freq = self.get_pulse(f"X180 {qb.name}")[
+                        'mod_frequency']
+                    pulsar = qb.instr_pulsar.get_instr()
+                    param = pulsar.parameters[f'{qb.ge_I_channel()}_mod_freq']
+                    qb_sweep_functions.append(
+                        swf.Offset_Sweep(param, mod_freq))
+                minor_sweep_functions.append(swf.multi_sweep_function(
+                    qb_sweep_functions))
+            sweep_functions = [
+                swf.MajorMinorSweep(majsp, minsp,
+                                    np.array(self.allowed_lo_freqs) - offset)
+                for majsp, minsp, offset in zip(
+                    sweep_functions, minor_sweep_functions,
+                    self.lo_offsets.values())]
         self.sweep_functions = [
             self.sweep_functions[0], swf.multi_sweep_function(
                 sweep_functions, name=name, parameter_name=name)]

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -352,6 +352,10 @@ class ParallelLOSweepExperiment(CalibBuilder):
 
         for task in self.task_list:
             if 'fp_assisted_ro_calib_flux' in task and 'fluxline' in task:
+                if self.qubits is None:
+                    log.warning('No qubit objects provided. Creating the '
+                                'sequence without RO flux amplitude.')
+                    break
                 qb = self.get_qubits(task['qb'])[0][0]
                 if qb.ro_pulse_type() != 'GaussFilteredCosIQPulseWithFlux':
                     continue

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -283,8 +283,10 @@ class ParallelLOSweepExperiment(CalibBuilder):
         if self.allowed_lo_freqs is not None:
             for task in self.preprocessed_task_list:
                 task['pulse_modifs'] = {'attr=mod_frequency': None}
+            self.cal_points.pulse_modifs = {'*.mod_frequency': [None]}
 
     def run_measurement(self, **kw):
+        temp_vals = []
         name = 'Drive frequency shift'
         sweep_functions = [swf.Offset_Sweep(
             lo.frequency, offset, name=name, parameter_name=name, unit='Hz')
@@ -298,6 +300,10 @@ class ParallelLOSweepExperiment(CalibBuilder):
                         'mod_frequency']
                     pulsar = qb.instr_pulsar.get_instr()
                     param = pulsar.parameters[f'{qb.ge_I_channel()}_mod_freq']
+                    # The following temporary value ensures that HDAWG
+                    # modulation is set back to its previous state after the end
+                    # of the modulation frequency sweep.
+                    temp_vals.append((param, None))
                     qb_sweep_functions.append(
                         swf.Offset_Sweep(param, mod_freq))
                 minor_sweep_functions.append(swf.multi_sweep_function(
@@ -312,7 +318,8 @@ class ParallelLOSweepExperiment(CalibBuilder):
             self.sweep_functions[0], swf.multi_sweep_function(
                 sweep_functions, name=name, parameter_name=name)]
         self.mc_points[1] = self.lo_sweep_points
-        super().run_measurement(**kw)
+        with temporary_value(*temp_vals):
+            super().run_measurement(**kw)
 
     def get_meas_objs_from_task(self, task):
         return [task['qb']]

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -248,45 +248,26 @@ class ParallelLOSweepExperiment(CalibBuilder):
         it specifies that the LO should only be set to frequencies in the
         list, and the desired drive frequency is obtained by an IF sweep
         using internal modulation of the HDAWG. This requires an HDAWG as
-        drive AWG.
+        drive AWG. Consider using the kwarg optimize_mod_freqs together with
+        allowed_lo_freqs (see docstring of resolve_freq_sweep_points).
     :param adapt_drive_amp: (bool) (*) if True, the drive amplitude is adapted
         for each drive frequency based on the parameter
         fit_ge_amp180_over_ge_freq of the qubit using the output amplitude
-        scaling of the HDAWG. This requires an HDAWG as drive AWG.
+        scaling of the HDAWG. This requires an HDAWG as drive AWG. Note the
+        kwarg adapt_cal_point_drive_amp, which can be used together
+        with adapt_drive_amp (see docstring of resolve_freq_sweep_points).
     :param adapt_ro_freq: (bool, default: False) (*) if True, the RO LO
         frequency is adapted for each drive frequency based on the parameter
         fit_ro_freq_over_ge_freq of the qubit
 
     :param kw: keyword arguments.
-        The following kwargs are interpreted by resolve_freq_sweep_points:
-        optimize_mod_freqs: (bool, default: False) If False, the ge_mod_freq
-            setting of the first qb on an LO (according to the  ordering of
-            the task list) determines the LO frequency for all qubits on
-            that LO. If True, the ge_mod_freq settings will be optimized for
-            the following situations:
-            - With allowed_lo_freqs set to None: the LO will be placed in
-                the center of the band of drive frequencies of all qubits on
-                that LO (minimizing the maximum absolute value of
-                ge_mod_freq over all qubits). Do not use in case of a single
-                qubit per LO in this case, as it would result in a
-                ge_mod_freq of 0.
-            - With a list allowed_lo_freqs provided: the ge_mod_freq setting of
-                the qubit would act as an unnecessary constant offset in the
-                IF sweep, and optimize_mod_freqs can be used to minimize
-                this offset. In this case optimize_mod_freqs can (and
-                should) even be used in case of a single qubit per LO (where
-                it reduces this offset to 0).
-        adapt_cal_point_drive_amp: (bool, default: False) If adapt_drive_amp
-            is used, this decides whether the drive amplitude should also be
-            adapted for calibration points. To implement the case where this
-            is False, it is assumed that the calibration point of interest
-            is the one at the drive frequency configured in ge_freq of the
-            qubit and that the ge_amp180 in the qubit is calibrated for that
-            frequency.
+        The following kwargs are interpreted by resolve_freq_sweep_points
+        (see docstring of that method):
+        - optimize_mod_freqs
+        - adapt_cal_point_drive_amp
 
         Moreover, keyword arguments are passed to preprocess_task_list,
         parallel_sweep, and to the parent class.
-
     """
 
     def __init__(self, task_list, sweep_points=None, allowed_lo_freqs=None,
@@ -335,7 +316,31 @@ class ParallelLOSweepExperiment(CalibBuilder):
         :param freq_sp_suffix: (str, default 'freq') To identify the
             frequency sweep parameter, this string specifies a suffix that is
             contained at the end of the name of the frequency sweep parameter.
-        :param kw: keyword arguments, see class docstring
+        :param kw:
+            optimize_mod_freqs: (bool, default: False) If False, the
+                ge_mod_freq setting of the first qb on an LO (according to
+                the ordering of the task list) determines the LO frequency
+                for all qubits on that LO. If True, the ge_mod_freq settings
+                will be optimized for the following situations:
+                - With allowed_lo_freqs set to None: the LO will be placed in
+                  the center of the band of drive frequencies of all qubits on
+                  that LO (minimizing the maximum absolute value of
+                  ge_mod_freq over all qubits). Do not use in case of a single
+                  qubit per LO in this case, as it would result in a
+                  ge_mod_freq of 0.
+                - With a list allowed_lo_freqs provided: the ge_mod_freq
+                  setting of the qubit would act as an unnecessary constant
+                  offset in the IF sweep, and optimize_mod_freqs can be used
+                  to minimize this offset. In this case optimize_mod_freqs
+                  can (and should) even be used in case of a single qubit
+                  per LO (where it reduces this offset to 0).
+            adapt_cal_point_drive_amp: (bool, default: False) If
+                adapt_drive_amp is used, this decides whether the drive
+                amplitude should also be adapted for calibration points. To
+                implement the case where this is False, it is assumed that
+                the calibration point of interest is the one at the drive
+                frequency configured in ge_freq of the qubit and that the
+                ge_amp180 in the qubit is calibrated for that frequency.
         """
         all_freqs = np.array(
             self.sweep_points.get_sweep_params_property('values', 1, 'all'))

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -243,13 +243,14 @@ class ParallelLOSweepExperiment(CalibBuilder):
             self.preprocessed_task_list, self.sweep_block, **kw)
 
     def resolve_lo_sweep_points(self, freq_sp_suffix='freq', **kw):
-        all_freqs = self.sweep_points.get_sweep_params_property('values', 1,
-                                                                'all')
+        all_freqs = np.array(
+            self.sweep_points.get_sweep_params_property('values', 1, 'all'))
         if np.ndim(all_freqs) == 1:
             all_freqs = [all_freqs]
         all_diffs = [np.diff(freqs) for freqs in all_freqs]
-        assert all([np.mean(abs(diff - all_diffs[0]) / all_diffs[0]) < 1e-10
-                    for diff in all_diffs]), \
+        assert all([len(d) == 0 for d in all_diffs]) or \
+            all([np.mean(abs(diff - all_diffs[0]) / all_diffs[0]) < 1e-10
+                 for diff in all_diffs]), \
             "The steps between frequency sweep points must be the same for " \
             "all qubits."
         self.lo_sweep_points = all_freqs[0] - all_freqs[0][0]

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -216,7 +216,7 @@ class T1FrequencySweep(CalibBuilder):
 
 class ParallelLOSweepExperiment(CalibBuilder):
     def __init__(self, task_list, sweep_points=None, allowed_lo_freqs=None,
-                 adapt_drive_amp=False, **kw):
+                 adapt_drive_amp=False, adapt_ro_freq=False, **kw):
         for task in task_list:
             if not isinstance(task['qb'], str):
                 task['qb'] = task['qb'].name
@@ -227,14 +227,17 @@ class ParallelLOSweepExperiment(CalibBuilder):
         # needed there) makes sure that they are stored in the metadata.
         super().__init__(task_list, sweep_points=sweep_points,
                          allowed_lo_freqs=allowed_lo_freqs,
-                         adapt_drive_amp=adapt_drive_amp, **kw)
+                         adapt_drive_amp=adapt_drive_amp,
+                         adapt_ro_freq=adapt_ro_freq, **kw)
         self.lo_offsets = {}
         self.lo_qubits = {}
         self.qb_offsets = {}
         self.lo_sweep_points = []
         self.allowed_lo_freqs = allowed_lo_freqs
         self.adapt_drive_amp = adapt_drive_amp
+        self.adapt_ro_freq = adapt_ro_freq
         self.drive_amp_adaptation = {}
+        self.ro_freq_adaptation = {}
         self.analysis = {}
 
         self.preprocessed_task_list = self.preprocess_task_list(**kw)
@@ -324,6 +327,28 @@ class ParallelLOSweepExperiment(CalibBuilder):
                 qb.name: fnc(self.lo_sweep_points)
                 for qb, fnc in self.drive_amp_adaptation.items()}
 
+        if self.adapt_ro_freq and self.qubits is None:
+            log.warning('No qubit objects provided. Creating the sequence '
+                        'without adapting RO freq.')
+        elif self.adapt_ro_freq:
+            for task in self.task_list:
+                qb = self.get_qubits(task['qb'])[0][0]
+                if qb.get_ro_freq_from_ge_freq(qb.ge_freq()) is None:
+                    continue
+                ro_mwg = qb.instr_ro_lo.get_instr()
+                if ro_mwg in self.ro_freq_adaptation:
+                    raise NotImplementedError(
+                        f'RO adaptation for {qb.name} with LO {ro_mwg.name}: '
+                        f'Parallel RO frequency adaptation for qubits '
+                        f'sharing an LO is not implemented.')
+                self.ro_freq_adaptation[ro_mwg] = (
+                    lambda x, mwg=ro_mwg, o=self.qb_offsets[qb],
+                           f_mod=qb.ro_mod_freq():
+                    qb.get_ro_freq_from_ge_freq(x + o) - f_mod)
+            self.exp_metadata['ro_freq_adaptation'] = {
+                mwg.name: fnc(self.lo_sweep_points)
+                for mwg, fnc in self.ro_freq_adaptation.items()}
+
         with temporary_value(*temp_vals):
             self.update_operation_dict()
 
@@ -377,6 +402,13 @@ class ParallelLOSweepExperiment(CalibBuilder):
                 # amplitude scaling is set back to its previous state after the
                 # end of the sweep.
                 temp_vals.append((param, 1.0))
+        for mwg, adaptation in self.ro_freq_adaptation.items():
+            adapt_name = f'RO freq adaptation freq {mwg.name}'
+            param = mwg.frequency
+            sweep_functions += [swf.Transformed_Sweep(
+                param, transformation=adaptation,
+                name=adapt_name, parameter_name=adapt_name, unit='Hz')]
+            temp_vals.append((param, param()))
         for task in self.task_list:
             if 'fluxline' not in task:
                 continue

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -216,7 +216,7 @@ class T1FrequencySweep(CalibBuilder):
 
 class ParallelLOSweepExperiment(CalibBuilder):
     def __init__(self, task_list, sweep_points=None, allowed_lo_freqs=None,
-                 **kw):
+                 adapt_drive_amp=False, **kw):
         for task in task_list:
             if not isinstance(task['qb'], str):
                 task['qb'] = task['qb'].name
@@ -228,6 +228,8 @@ class ParallelLOSweepExperiment(CalibBuilder):
         self.lo_qubits = {}
         self.lo_sweep_points = []
         self.allowed_lo_freqs = allowed_lo_freqs
+        self.adapt_drive_amp = adapt_drive_amp
+        self.drive_amp_adaptation = {}
         self.analysis = {}
 
         self.preprocessed_task_list = self.preprocess_task_list(**kw)
@@ -247,11 +249,11 @@ class ParallelLOSweepExperiment(CalibBuilder):
             "all qubits."
         self.lo_sweep_points = all_freqs[0] - all_freqs[0][0]
 
+        temp_vals = []
         if self.qubits is None:
             log.warning('No qubit objects provided. Creating the sequence '
                         'without checking for ge_mod_freq corrections.')
         else:
-            temp_vals = []
             f_start = {}
             for task in self.task_list:
                 qb = self.get_qubits(task['qb'])[0][0]
@@ -277,13 +279,33 @@ class ParallelLOSweepExperiment(CalibBuilder):
                     temp_vals.append(
                         (qb.ge_mod_freq, f_start[qb] - self.lo_offsets[lo]))
 
-            with temporary_value(*temp_vals):
-                self.update_operation_dict()
-
         if self.allowed_lo_freqs is not None:
             for task in self.preprocessed_task_list:
                 task['pulse_modifs'] = {'attr=mod_frequency': None}
             self.cal_points.pulse_modifs = {'*.mod_frequency': [None]}
+
+        if self.adapt_drive_amp and self.qubits is None:
+            log.warning('No qubit objects provided. Creating the sequence '
+                        'without adapting drive amp.')
+        elif self.adapt_drive_amp:
+            for task in self.task_list:
+                qb = self.get_qubits(task['qb'])[0][0]
+                sp = self.exp_metadata['meas_obj_sweep_points_map'][qb.name]
+                freq_sp = [s for s in sp if s.endswith(freq_sp_suffix)][0]
+                f = self.sweep_points.get_sweep_params_property(
+                    'values', 1, freq_sp)
+                amps = qb.get_ge_amp180_from_ge_freq(np.array(f))
+                if amps is None:
+                    continue
+                max_amp = np.max(amps)
+                temp_vals.append((qb.ge_amp180, max_amp))
+                self.drive_amp_adaptation[qb] = (
+                    lambda x, qb=qb, s=max_amp,
+                           o=f[0] - self.lo_sweep_points[0] :
+                    qb.get_ge_amp180_from_ge_freq(x + o) / s)
+
+        with temporary_value(*temp_vals):
+            self.update_operation_dict()
 
     def run_measurement(self, **kw):
         temp_vals = []
@@ -314,6 +336,19 @@ class ParallelLOSweepExperiment(CalibBuilder):
                 for majsp, minsp, offset in zip(
                     sweep_functions, minor_sweep_functions,
                     self.lo_offsets.values())]
+        for qb, adaptation in self.drive_amp_adaptation.items():
+            adapt_name = f'Drive amp adaptation freq {qb.name}'
+            pulsar = qb.instr_pulsar.get_instr()
+            for quad in ['I', 'Q']:
+                ch = qb.get(f'ge_{quad}_channel')
+                param = pulsar.parameters[f'{ch}_amplitude_scaling']
+                sweep_functions += [swf.Transformed_Sweep(
+                    param, transformation=adaptation,
+                    name=adapt_name, parameter_name=adapt_name, unit='Hz')]
+                # The following temporary value ensures that HDAWG
+                # amplitude scaling is set back to its previous state after the
+                # end of the sweep.
+                temp_vals.append((param, 1.0))
         self.sweep_functions = [
             self.sweep_functions[0], swf.multi_sweep_function(
                 sweep_functions, name=name, parameter_name=name)]

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -1204,3 +1204,30 @@ class FluxPulseAmplitudeSweep(ParallelLOSweepExperiment):
         for qb in self.meas_obj_names:
             qb.fit_ge_freq_from_flux_pulse_amp(
                 self.analysis.fit_res[f'freq_fit_{qb.name}'].best_values)
+
+
+class RabiFrequencySweep(ParallelLOSweepExperiment):
+    kw_for_sweep_points = {
+        'freqs': dict(param_name='freq', unit='Hz',
+                      label=r'drive frequency, $f_d$',
+                      dimension=1),
+        'amps': dict(param_name='amplitude', unit='V',
+                       label=r'drive pulse amplitude',
+                       dimension=0),
+    }
+
+    def __init__(self, task_list, sweep_points=None, **kw):
+        try:
+            self.experiment_name = 'RabiFrequencySweep'
+            super().__init__(task_list, sweep_points=sweep_points, **kw)
+            self.autorun(**kw)
+
+        except Exception as x:
+            self.exception = x
+            traceback.print_exc()
+
+    def sweep_block(self, qb, **kw):
+        b = self.block_from_ops(f'ge {qb}', [f'X180 {qb}'])
+        b.pulses[0]['amplitude'] = ParametricValue('amplitude')
+        self.data_to_fit.update({qb: 'pe'})
+        return b

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -230,6 +230,7 @@ class ParallelLOSweepExperiment(CalibBuilder):
                          adapt_drive_amp=adapt_drive_amp, **kw)
         self.lo_offsets = {}
         self.lo_qubits = {}
+        self.qb_offsets = {}
         self.lo_sweep_points = []
         self.allowed_lo_freqs = allowed_lo_freqs
         self.adapt_drive_amp = adapt_drive_amp
@@ -265,6 +266,7 @@ class ParallelLOSweepExperiment(CalibBuilder):
                 freq_sp = [s for s in sp if s.endswith(freq_sp_suffix)][0]
                 f_start[qb] = self.sweep_points.get_sweep_params_property(
                     'values', 1, freq_sp)[0]
+                self.qb_offsets[qb] = f_start[qb] - self.lo_sweep_points[0]
                 lo = qb.instr_ge_lo.get_instr()
                 if lo not in self.lo_qubits:
                     self.lo_qubits[lo] = [qb]
@@ -305,7 +307,7 @@ class ParallelLOSweepExperiment(CalibBuilder):
                 temp_vals.append((qb.ge_amp180, max_amp))
                 self.drive_amp_adaptation[qb] = (
                     lambda x, qb=qb, s=max_amp,
-                           o=f[0] - self.lo_sweep_points[0] :
+                           o=self.qb_offsets[qb] :
                     qb.get_ge_amp180_from_ge_freq(x + o) / s)
                 if not kw.get('adapt_cal_point_drive_amp', False):
                     if self.cal_points.pulse_modifs is None:
@@ -360,6 +362,20 @@ class ParallelLOSweepExperiment(CalibBuilder):
                 # amplitude scaling is set back to its previous state after the
                 # end of the sweep.
                 temp_vals.append((param, 1.0))
+        for task in self.task_list:
+            if 'fluxline' not in task:
+                continue
+            qb = self.get_qubits(task['qb'])[0][0]
+            # offs = self.lo_offsets[[lo for lo, qbs in self.lo_qubits.items()
+            #                         if qb in qbs][0]]
+            dc_amp = (
+                lambda x, o=self.qb_offsets[qb],
+                       vfc=qb.fit_ge_freq_from_dc_offset() :
+                fit_mods.Qubit_freq_to_dac_res(np.array([x + o]), **vfc)[0])
+            sweep_functions += [swf.Transformed_Sweep(
+                task['fluxline'], transformation=dc_amp,
+                name=f'DC Offset {qb.name}',
+                parameter_name=f'Parking freq {qb.name}', unit='Hz')]
         self.sweep_functions = [
             self.sweep_functions[0], swf.multi_sweep_function(
                 sweep_functions, name=name, parameter_name=name)]

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -1314,6 +1314,30 @@ class FluxPulseAmplitudeSweep(ParallelLOSweepExperiment):
 
 
 class RabiFrequencySweep(ParallelLOSweepExperiment):
+    """
+    Performs a series of ge Rabi experiments for multiple drive frequencies.
+    This is a ParallelLOSweepExperiment, see docstrings of
+    ParallelLOSweepExperiment, MultiTaskingExperiment and CalibBuilder
+    for general information.
+
+           |X180|          ---         |RO|
+      sweep amp & freq
+
+    Important notes (see docstring of ParallelLOSweepExperiment for details):
+    - Each task corresponds to a qubit (specified by the key qb in the
+      task), i.e., multiple qubits can be characterized in parallel.
+    - Some options of ParallelLOSweepExperiment have not yet been
+      exhaustively tested for parallel measurements.
+    - The key fluxline in a task can be set to a qcodes parameter to adjust
+      the DC flux offset of the qubit during the sweep.
+
+    :param kw:
+        Keyword arguments are passed on to the super class and to autorun.
+
+        The following kwargs are automatically converted to sweep points:
+        - amps: drive pulse amplitude (sweep dimension 0)
+        - freqs: drive frequency (sweep dimension 1)
+    """
     kw_for_sweep_points = {
         'freqs': dict(param_name='freq', unit='Hz',
                       label=r'drive frequency, $f_d$',
@@ -1334,6 +1358,12 @@ class RabiFrequencySweep(ParallelLOSweepExperiment):
             traceback.print_exc()
 
     def sweep_block(self, qb, **kw):
+        """
+        This function creates the block for a single RabiFrequencySweep
+        measurement task, see the pulse sequence in the class docstring.
+        :param qb: (str) the qubit name
+        :param kw: currently ignored
+        """
         b = self.block_from_ops(f'ge {qb}', [f'X180 {qb}'])
         b.pulses[0]['amplitude'] = ParametricValue('amplitude')
         self.data_to_fit.update({qb: 'pe'})

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -254,6 +254,7 @@ class ParallelLOSweepExperiment(CalibBuilder):
             "The steps between frequency sweep points must be the same for " \
             "all qubits."
         self.lo_sweep_points = all_freqs[0] - all_freqs[0][0]
+        self.exp_metadata['lo_sweep_points'] = self.lo_sweep_points
 
         temp_vals = []
         if self.qubits is None:
@@ -285,6 +286,8 @@ class ParallelLOSweepExperiment(CalibBuilder):
                                                   - qb.ge_mod_freq()
                     temp_vals.append(
                         (qb.ge_mod_freq, f_start[qb] - self.lo_offsets[lo]))
+            self.exp_metadata['lo_offsets'] = {
+                k.name: v for k, v in self.lo_offsets.items()}
 
         if self.allowed_lo_freqs is not None:
             for task in self.preprocessed_task_list:
@@ -317,6 +320,9 @@ class ParallelLOSweepExperiment(CalibBuilder):
                         {f'e_X180 {qb.name}*.amplitude': [
                             qb.ge_amp180() / (qb.get_ge_amp180_from_ge_freq(
                                 qb.ge_freq()) / max_amp)]})
+            self.exp_metadata['drive_amp_adaptation'] = {
+                qb.name: fnc(self.lo_sweep_points)
+                for qb, fnc in self.drive_amp_adaptation.items()}
 
         with temporary_value(*temp_vals):
             self.update_operation_dict()

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -335,12 +335,20 @@ class ParallelLOSweepExperiment(CalibBuilder):
                         'mod_frequency']
                     pulsar = qb.instr_pulsar.get_instr()
                     param = pulsar.parameters[f'{qb.ge_I_channel()}_mod_freq']
+                    # Pulsar assumes that the first channel in a pair is the
+                    # I component. If this is not the case, the following
+                    # workaround swaps the sign of the modulation frequency
+                    # to get the correct sideband.
+                    iq_swapped = (int(qb.ge_I_channel()[-1:])
+                                  > int(qb.ge_Q_channel()[-1:]))
                     # The following temporary value ensures that HDAWG
                     # modulation is set back to its previous state after the end
                     # of the modulation frequency sweep.
                     temp_vals.append((param, None))
                     qb_sweep_functions.append(
-                        swf.Offset_Sweep(param, mod_freq))
+                        swf.Transformed_Sweep(param, transformation=(
+                            lambda x, o=mod_freq, s=(-1 if iq_swapped else 1)
+                            : s * (x + o))))
                 minor_sweep_functions.append(swf.multi_sweep_function(
                     qb_sweep_functions))
             sweep_functions = [

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -307,6 +307,13 @@ class ParallelLOSweepExperiment(CalibBuilder):
                     lambda x, qb=qb, s=max_amp,
                            o=f[0] - self.lo_sweep_points[0] :
                     qb.get_ge_amp180_from_ge_freq(x + o) / s)
+                if not kw.get('adapt_cal_point_drive_amp', False):
+                    if self.cal_points.pulse_modifs is None:
+                        self.cal_points.pulse_modifs = {}
+                    self.cal_points.pulse_modifs.update(
+                        {f'e_X180 {qb.name}*.amplitude': [
+                            qb.ge_amp180() / (qb.get_ge_amp180_from_ge_freq(
+                                qb.ge_freq()) / max_amp)]})
 
         with temporary_value(*temp_vals):
             self.update_operation_dict()

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -494,13 +494,16 @@ class ParallelLOSweepExperiment(CalibBuilder):
                     mod_freq = self.get_pulse(f"X180 {qb.name}")[
                         'mod_frequency']
                     pulsar = qb.instr_pulsar.get_instr()
-                    param = pulsar.parameters[f'{qb.ge_I_channel()}_mod_freq']
                     # Pulsar assumes that the first channel in a pair is the
                     # I component. If this is not the case, the following
-                    # workaround swaps the sign of the modulation frequency
-                    # to get the correct sideband.
+                    # workaround finds the correct channel to configure
+                    # and swaps the sign of the modulation frequency to get
+                    # the correct sideband.
                     iq_swapped = (int(qb.ge_I_channel()[-1:])
                                   > int(qb.ge_Q_channel()[-1:]))
+                    param = pulsar.parameters[
+                        f'{qb.ge_Q_channel()}_mod_freq' if iq_swapped else
+                        f'{qb.ge_I_channel()}_mod_freq']
                     # The following temporary value ensures that HDAWG
                     # modulation is set back to its previous state after the end
                     # of the modulation frequency sweep.

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -238,6 +238,7 @@ class ParallelLOSweepExperiment(CalibBuilder):
         self.adapt_ro_freq = adapt_ro_freq
         self.drive_amp_adaptation = {}
         self.ro_freq_adaptation = {}
+        self.ro_flux_amp_adaptation = {}
         self.analysis = {}
 
         self.preprocessed_task_list = self.preprocess_task_list(**kw)
@@ -349,6 +350,31 @@ class ParallelLOSweepExperiment(CalibBuilder):
                 mwg.name: fnc(self.lo_sweep_points)
                 for mwg, fnc in self.ro_freq_adaptation.items()}
 
+        for task in self.task_list:
+            if 'fp_assisted_ro_calib_flux' in task and 'fluxline' in task:
+                qb = self.get_qubits(task['qb'])[0][0]
+                if qb.ro_pulse_type() != 'GaussFilteredCosIQPulseWithFlux':
+                    continue
+                sp = self.exp_metadata['meas_obj_sweep_points_map'][qb.name]
+                freq_sp = [s for s in sp if s.endswith(freq_sp_suffix)][0]
+                f = self.sweep_points.get_sweep_params_property(
+                    'values', 1, freq_sp)
+                ro_fp_amp = lambda x, qb=qb, cal_flux=task[
+                    'fp_assisted_ro_calib_flux'] : qb.ro_flux_amplitude() - (
+                        qb.calculate_flux_voltage(x) -
+                        qb.calculate_voltage_from_flux(cal_flux)) \
+                        * qb.flux_amplitude_bias_ratio()
+                amps = ro_fp_amp(f)
+                max_amp = np.max(np.abs(amps))
+                temp_vals.append((qb.ro_flux_amplitude, max_amp))
+                self.ro_flux_amp_adaptation[qb] = (
+                    lambda x, fnc=ro_fp_amp, s=max_amp, o=self.qb_offsets[qb]:
+                    fnc(x + o) / s)
+                if 'ro_flux_amp_adaptation' not in self.exp_metadata:
+                    self.exp_metadata['ro_flux_amp_adaptation'] = {}
+                self.exp_metadata['ro_flux_amp_adaptation'][qb.name] = \
+                    amps / max_amp
+
         with temporary_value(*temp_vals):
             self.update_operation_dict()
 
@@ -405,6 +431,23 @@ class ParallelLOSweepExperiment(CalibBuilder):
         for mwg, adaptation in self.ro_freq_adaptation.items():
             adapt_name = f'RO freq adaptation freq {mwg.name}'
             param = mwg.frequency
+            sweep_functions += [swf.Transformed_Sweep(
+                param, transformation=adaptation,
+                name=adapt_name, parameter_name=adapt_name, unit='Hz')]
+            temp_vals.append((param, param()))
+        for qb, adaptation in self.ro_flux_amp_adaptation.items():
+            adapt_name = f'RO flux amp adaptation freq {qb.name}'
+            pulsar = qb.instr_pulsar.get_instr()
+            ch = qb.get(f'ro_flux_channel')
+            for seg in self.sequences[0].segments.values():
+                for p in seg.unresolved_pulses:
+                    if (ch in p.pulse_obj.channels and
+                        p.pulse_obj.pulse_type
+                            != 'GaussFilteredCosIQPulseWithFlux'):
+                        raise NotImplementedError(
+                            'RO flux amp adaptation cannot be used when the '
+                            'sequence contains other flux pulses.')
+            param = pulsar.parameters[f'{ch}_amplitude_scaling']
             sweep_functions += [swf.Transformed_Sweep(
                 param, transformation=adaptation,
                 name=adapt_name, parameter_name=adapt_name, unit='Hz')]

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -215,6 +215,80 @@ class T1FrequencySweep(CalibBuilder):
 
 
 class ParallelLOSweepExperiment(CalibBuilder):
+    """
+    Base class for (parallel) calibration measurements where the LO is swept
+    in sweep dimension 1. The class is based on the concept of a
+    multitasking experiment, see docstrings of MultiTaskingExperiment and
+    of CalibBuilder for general information.
+
+    The following keys in a task are interpreted by this class:
+    - qb: identifies the qubit measured in the task (child classes should be
+        implemented in a way that they adopt this convention)
+    - fluxline: qcodes parameter to adjust the DC flux offset of the qubit.
+        If this is provided, the DC flux offset will be swept together with
+        the frequency sweep such that the qubit is tuned to the current
+        drive frequency (based on the fit_ge_freq_from_dc_offset parameter
+        in the qubit object).
+    - fp_assisted_ro_calib_flux (to be used in combination with fluxline):
+        Specifies the flux (in units of Phi0 with 0 indicating the upper
+        sweep spot) for which the flux-pulse-assisted RO of the qubit has
+        been calibrated. If this is provided and fluxline is provided,
+        the amplitude of the flux pulse assisted RO will be adjusted
+        together with the DC offset during the frequency sweep in order to
+        keep the qubit frequency during RO the same as in the calibration.
+        This required an HDAWG as flux AWG.
+
+    Note: parameters with a (*) have not been exhaustively tested for
+    parallel measurements.
+
+    :param task_list:  see MultiTaskingExperiment
+    :param sweep_points: (SweepPoints object or list of dicts or None)
+        sweep points valid for all tasks.
+    :param allowed_lo_freqs: (list of float or None) (*) if not None,
+        it specifies that the LO should only be set to frequencies in the
+        list, and the desired drive frequency is obtained by an IF sweep
+        using internal modulation of the HDAWG. This requires an HDAWG as
+        drive AWG.
+    :param adapt_drive_amp: (bool) (*) if True, the drive amplitude is adapted
+        for each drive frequency based on the parameter
+        fit_ge_amp180_over_ge_freq of the qubit using the output amplitude
+        scaling of the HDAWG. This requires drive AWG.
+    :param adapt_ro_freq: (bool, default: False) (*) if True, the RO LO
+        frequency is adapted for each drive frequency based on the parameter
+        fit_ro_freq_over_ge_freq of the qubit
+
+    :param kw: keyword arguments.
+        The following kw arguments are interpreted by resolve_lo_sweep_points:
+        optimize_mod_freqs: (bool, default: False) If False, the ge_mod_freq
+            setting of the first qb on an LO (according to the  ordering of
+            the task list) determines the LO frequency for all qubits on
+            that LO. If True, the ge_mod_freq settings will be optimized for
+            the following situations:
+            - With allowed_lo_freqs set to False: the LO will be placed in
+                the center of the band of drive frequencies of all qubits on
+                that LO (minimizing the maximum absolute value of
+                ge_mod_freq over all qubits). Do not use in case of a single
+                qubit per LO in this case, as it would result in a
+                ge_mod_freq of 0.
+            - With allowed_lo_freqs set to True: the ge_mod_freq setting of
+                the qubit would act as an unnecessary constant offset in the
+                IF sweep, and optimize_mod_freqs can be used to minimize
+                this offset. In this case optimize_mod_freqs can (and
+                should) even be used in case of a single qubit per LO (where
+                it reduces this offset to 0).
+        adapt_cal_point_drive_amp: (bool, default: False) If adapt_drive_amp
+            is used, this decides whether the drive amplitude should also be
+            adapted for calibration points. To implement the case where this
+            is False, it is assumed that the calibration point of interest
+            is the one at the drive frequency configured in ge_freq of the
+            qubit and that the ge_amp180 in the qubit is calibrated for that
+            frequency.
+
+        Moreover, keyword arguments are passed to preprocess_task_list,
+        parallel_sweep, and to the parent class.
+
+    """
+
     def __init__(self, task_list, sweep_points=None, allowed_lo_freqs=None,
                  adapt_drive_amp=False, adapt_ro_freq=False, **kw):
         for task in task_list:
@@ -247,6 +321,12 @@ class ParallelLOSweepExperiment(CalibBuilder):
             self.preprocessed_task_list, self.sweep_block, **kw)
 
     def resolve_lo_sweep_points(self, freq_sp_suffix='freq', **kw):
+        """
+        :param freq_sp_suffix: (str, default 'freq') To identify the
+            frequency sweep parameter, this string specifies a suffix that is
+            contained at the end of the name of the frequency sweep parameter.
+        :param kw: keyword arguments, see class docstring
+        """
         all_freqs = np.array(
             self.sweep_points.get_sweep_params_property('values', 1, 'all'))
         if np.ndim(all_freqs) == 1:
@@ -261,6 +341,9 @@ class ParallelLOSweepExperiment(CalibBuilder):
         self.exp_metadata['lo_sweep_points'] = self.lo_sweep_points
 
         temp_vals = []
+        # Determine which qubits share an LO, and update ge_mod_freq settings
+        # - for compatibility in parallel LO sweeps with shared LOs
+        # - taking into account the optimize_mod_freqs kwarg
         if self.qubits is None:
             log.warning('No qubit objects provided. Creating the sequence '
                         'without checking for ge_mod_freq corrections.')
@@ -294,10 +377,14 @@ class ParallelLOSweepExperiment(CalibBuilder):
                 k.name: v for k, v in self.lo_offsets.items()}
 
         if self.allowed_lo_freqs is not None:
+            # HDAWG internal modulation is needed, switch off modulation in
+            # the waveform generation
             for task in self.preprocessed_task_list:
                 task['pulse_modifs'] = {'attr=mod_frequency': None}
             self.cal_points.pulse_modifs = {'*.mod_frequency': [None]}
 
+        # If applicable, configure drive amplitude adaptation based on the
+        # models stored in the qubit objects.
         if self.adapt_drive_amp and self.qubits is None:
             log.warning('No qubit objects provided. Creating the sequence '
                         'without adapting drive amp.')
@@ -328,6 +415,8 @@ class ParallelLOSweepExperiment(CalibBuilder):
                 qb.name: fnc(self.lo_sweep_points)
                 for qb, fnc in self.drive_amp_adaptation.items()}
 
+        # If applicable, configure RO frequency adaptation based on the
+        # models stored in the qubit objects.
         if self.adapt_ro_freq and self.qubits is None:
             log.warning('No qubit objects provided. Creating the sequence '
                         'without adapting RO freq.')
@@ -350,6 +439,10 @@ class ParallelLOSweepExperiment(CalibBuilder):
                 mwg.name: fnc(self.lo_sweep_points)
                 for mwg, fnc in self.ro_freq_adaptation.items()}
 
+        # If applicable, configure flux amplitude adaptation for
+        # flux-pulse-assisted RO (based on the models stored in the qubit
+        # objects) for cases where the DC offset is swept together with the
+        # frequency sweep.
         for task in self.task_list:
             if 'fp_assisted_ro_calib_flux' in task and 'fluxline' in task:
                 if self.qubits is None:
@@ -383,6 +476,11 @@ class ParallelLOSweepExperiment(CalibBuilder):
             self.update_operation_dict()
 
     def run_measurement(self, **kw):
+        """
+        Configures additional sweep functions and temporary values for the
+        functionality configured in resolve_lo_sweep_points, before calling
+        the method of the base class.
+        """
         temp_vals = []
         name = 'Drive frequency shift'
         sweep_functions = [swf.Offset_Sweep(

--- a/pycqed/measurement/calibration/single_qubit_gates.py
+++ b/pycqed/measurement/calibration/single_qubit_gates.py
@@ -223,7 +223,11 @@ class ParallelLOSweepExperiment(CalibBuilder):
             if not 'prefix' in task:
                 task['prefix'] = f"{task['qb']}_"
 
-        super().__init__(task_list, sweep_points=sweep_points, **kw)
+        # Passing keyword arguments to the super class (even if they are not
+        # needed there) makes sure that they are stored in the metadata.
+        super().__init__(task_list, sweep_points=sweep_points,
+                         allowed_lo_freqs=allowed_lo_freqs,
+                         adapt_drive_amp=adapt_drive_amp, **kw)
         self.lo_offsets = {}
         self.lo_qubits = {}
         self.lo_sweep_points = []

--- a/pycqed/measurement/calibration/two_qubit_gates.py
+++ b/pycqed/measurement/calibration/two_qubit_gates.py
@@ -302,7 +302,8 @@ class MultiTaskingExperiment(QuantumExperiment):
             keyword arguments for block_func, plus a key 'prefix' with a unique
             prefix string, plus optionally a key 'params_to_prefix' created
             by preprocess_task indicating which sweep parameters have to be
-            prefixed with the task prefix.
+            prefixed with the task prefix, plus optionally a key
+            pulse_modifs with pulse modifiers for the created blocks.
         :param block_func: a handle to a function that creates a block. As
             an alternative, a task-specific block_func can be given as a
             parameter of the task. If the block creation function instead
@@ -326,6 +327,7 @@ class MultiTaskingExperiment(QuantumExperiment):
             # the block creation function
             prefix = task.pop('prefix')
             params_to_prefix = task.pop('params_to_prefix', None)
+            pulse_modifs = task.pop('pulse_modifs', None)
             # the block_func passed as argument is used for all tasks that
             # do not define their own block_func
             if not 'block_func' in task:
@@ -338,6 +340,8 @@ class MultiTaskingExperiment(QuantumExperiment):
             if not isinstance(new_block, list):
                 new_block = [new_block]
             for b in new_block:
+                if pulse_modifs is not None:
+                    b.pulses = b.pulses_sweepcopy([pulse_modifs], [None])
                 # prefix the block names to avoid naming conflicts later on
                 b.name = prefix + b.name
                 # For the sweep points that need to be prefixed (see

--- a/pycqed/measurement/calibration/two_qubit_gates.py
+++ b/pycqed/measurement/calibration/two_qubit_gates.py
@@ -16,6 +16,7 @@ from pycqed.instrument_drivers.meta_instrument.qubit_objects.QuDev_transmon \
     import QuDev_transmon
 from pycqed.measurement import multi_qubit_module as mqm
 import logging
+import qcodes
 log = logging.getLogger(__name__)
 
 # TODO: docstrings (list all kw at the highest level with reference to where
@@ -147,7 +148,12 @@ class MultiTaskingExperiment(QuantumExperiment):
             'data_to_fit': self.data_to_fit,
         })
         if self.task_list is not None:
-            self.exp_metadata.update({'task_list': self.task_list})
+            tl = [copy(t) for t in self.task_list]
+            for t in tl:
+                for k, v in t.items():
+                    if isinstance(v, qcodes.Parameter):
+                        t[k] = repr(v)
+            self.exp_metadata.update({'task_list': tl})
 
         super().run_measurement(**kw)
 

--- a/pycqed/measurement/pulse_sequences/single_qubit_tek_seq_elts.py
+++ b/pycqed/measurement/pulse_sequences/single_qubit_tek_seq_elts.py
@@ -1039,7 +1039,7 @@ def add_preparation_pulses(pulse_list, operation_dict, qb_names,
         return preparation_pulses + pulse_list
 
 
-def sweep_pulse_params(pulses, params):
+def sweep_pulse_params(pulses, params, pulse_not_found_warning=True):
     """
     Sweeps a list of pulses over specified parameters.
     Args:
@@ -1051,6 +1051,8 @@ def sweep_pulse_params(pulses, params):
             all pulses with name starting with <pulse_starts_with> and ending
             with <pulse_endswith> will be modified. eg. "Rabi_*" will modify
             Rabi_1, Rabi_2 in [Rabi_1, Rabi_2, Other_Pulse]
+        pulse_not_found_warning (bool, default: True) whether a warning
+            should be issued if no pulse matches a given pulse name.
 
     Returns: a list of pulses_lists where each element is to be used
         for a single segment
@@ -1089,7 +1091,7 @@ def sweep_pulse_params(pulses, params):
             pulse_name, param_name = name.split('.')
             pulse_indices = [i for i, p in enumerate(pulses)
                              if check_pulse_name(p, pulse_name)]
-            if len(pulse_indices) == 0:
+            if len(pulse_indices) == 0 and pulse_not_found_warning:
                 log.warning(f"No pulse with name {pulse_name} found in list:"
                             f"{[p.get('name', 'No Name') for p in pulses]}")
             for p_idx in pulse_indices:

--- a/pycqed/measurement/quantum_experiment.py
+++ b/pycqed/measurement/quantum_experiment.py
@@ -537,9 +537,16 @@ class QuantumExperiment(CircuitBuilder):
                 'unit', 0, param_names=sweep_param_name)
         except TypeError:
             sweep_param_name, unit = "None", ""
-        sweep_func_1st_dim = self.sweep_functions[0](
-            sequence=self.sequences[0], upload=self.upload,
-            parameter_name=sweep_param_name,  unit=unit)
+        if self.sweep_functions[0] == awg_swf.SegmentHardSweep:
+            sweep_func_1st_dim = self.sweep_functions[0](
+                sequence=self.sequences[0], upload=self.upload,
+                parameter_name=sweep_param_name, unit=unit)
+        else:
+            # In case of an unknown sweep function type, it is assumed
+            # that self.sweep_functions[0] has already been initialized
+            # with all required parameters and can be directly passed to
+            # MC.
+            sweep_func_1st_dim = self.sweep_functions[0]
 
         self.MC.set_sweep_function(sweep_func_1st_dim)
         self.MC.set_sweep_points(self.mc_points[0])

--- a/pycqed/measurement/waveform_control/pulsar.py
+++ b/pycqed/measurement/waveform_control/pulsar.py
@@ -549,12 +549,17 @@ class HDAWG8Pulsar:
                            parameter_class=ManualParameter)
 
         for awg_nr in range(4):
-            self.add_parameter(f'{awg.name}_awgs_{awg_nr}_mod_freq',
+            param_name = f'{awg.name}_awgs_{awg_nr}_mod_freq'
+            self.add_parameter(param_name,
                                unit='Hz',
                                initial_value=None,
                                set_cmd=self._hdawg_mod_setter(awg, awg_nr),
                                get_cmd=self._hdawg_mod_getter(awg, awg_nr),
                                )
+            # qcodes will not set the initial value if it is None, so we set it
+            # manually here to ensure that internal modulation gets switched off
+            # in the init.
+            self.set(f'{awg.name}_awgs_{awg_nr}_mod_freq', None)
 
         group = []
         for ch_nr in range(8):

--- a/pycqed/measurement/waveform_control/pulsar.py
+++ b/pycqed/measurement/waveform_control/pulsar.py
@@ -663,7 +663,7 @@ class HDAWG8Pulsar:
             output = (int(id[2:]) - 1) - 2 * awg
             def s(val):
                 obj.set(f'awgs_{awg}_outputs_{output}_amplitude', val)
-                print(f'awgs_{awg}_outputs_{output}_amplitude: {val}')
+                log.debug(f'awgs_{awg}_outputs_{output}_amplitude: {val}')
         else:
             raise NotImplementedError('Unknown parameter {}'.format(par))
         return s
@@ -698,7 +698,7 @@ class HDAWG8Pulsar:
     @staticmethod
     def _hdawg_mod_setter(obj, awg_nr):
         def s(val):
-            print(f'{obj.name}_awgs_{awg_nr} modulation freq: {val}')
+            log.debug(f'{obj.name}_awgs_{awg_nr} modulation freq: {val}')
             if val == None:
                 obj.set(f'awgs_{awg_nr}_outputs_0_modulation_mode', 0)
                 obj.set(f'awgs_{awg_nr}_outputs_1_modulation_mode', 0)

--- a/pycqed/measurement/waveform_control/pulsar.py
+++ b/pycqed/measurement/waveform_control/pulsar.py
@@ -548,6 +548,14 @@ class HDAWG8Pulsar:
                                                vals.Lists(vals.Ints())),
                            parameter_class=ManualParameter)
 
+        for awg_nr in range(4):
+            self.add_parameter(f'{awg.name}_awgs_{awg_nr}_mod_freq',
+                               unit='Hz',
+                               initial_value=None,
+                               set_cmd=self._hdawg_mod_setter(awg, awg_nr),
+                               get_cmd=self._hdawg_mod_getter(awg, awg_nr),
+                               )
+
         group = []
         for ch_nr in range(8):
             id = 'ch{}'.format(ch_nr + 1)
@@ -605,7 +613,11 @@ class HDAWG8Pulsar:
         self.add_parameter('{}_internal_modulation'.format(name), 
                            initial_value=False, vals=vals.Bool(),
                            parameter_class=ManualParameter)
-    
+        cmd = self.parameters[
+            f'{awg.name}_awgs_{int((int(id[2:]) - 1) / 2)}_mod_freq']
+        self.add_parameter('{}_mod_freq'.format(name),
+                           unit='Hz', set_cmd=cmd, get_cmd=cmd)
+
     def _hdawg_create_marker_channel_parameters(self, id, name, awg):
         self.add_parameter('{}_id'.format(name), get_cmd=lambda _=id: _)
         self.add_parameter('{}_awg'.format(name), get_cmd=lambda _=awg.name: _)
@@ -659,7 +671,47 @@ class HDAWG8Pulsar:
                 return lambda: 1
         else:
             raise NotImplementedError('Unknown parameter {}'.format(par))
-        return g 
+        return g
+
+    @staticmethod
+    def _hdawg_mod_setter(obj, awg_nr):
+        def s(val):
+            print(f'{obj.name}_awgs_{awg_nr} modulation freq: {val}')
+            if val == None:
+                obj.set(f'awgs_{awg_nr}_outputs_0_modulation_mode', 0)
+                obj.set(f'awgs_{awg_nr}_outputs_1_modulation_mode', 0)
+            else:
+                # FIXME: implement SSB
+                sideband = np.sign(val)
+                freq = np.abs(val)
+                obj.set(f'awgs_{awg_nr}_outputs_0_modulation_mode', 1)
+                obj.set(f'awgs_{awg_nr}_outputs_1_modulation_mode', 2)
+                obj.set(f'sines_{awg_nr * 2}_oscselect', awg_nr * 4)
+                obj.set(f'sines_{awg_nr * 2 + 1}_oscselect', awg_nr * 4)
+                obj.set(f'sines_{awg_nr * 2}_phaseshift', 0)
+                obj.set(f'sines_{awg_nr * 2 + 1}_phaseshift', sideband * 90)
+                obj.set(f'oscs_{awg_nr * 4}_freq', freq)
+        return s
+
+    @staticmethod
+    def _hdawg_mod_getter(obj, awg_nr):
+        def g():
+            m0 = obj.get(f'awgs_{awg_nr}_outputs_0_modulation_mode')
+            m1 = obj.get(f'awgs_{awg_nr}_outputs_1_modulation_mode')
+            if m0 == 0 and m1 == 0:
+                return None
+            elif m0 == 1 and m1 == 2:
+                osc0 = obj.get(f'sines_{awg_nr * 2}_oscselect')
+                osc1 = obj.get(f'sines_{awg_nr * 2 + 1}_oscselect')
+                if osc0 == osc1:
+                    sideband = np.sign(obj.get(
+                        f'sines_{awg_nr * 2 + 1}_phaseshift'))
+                    return sideband * obj.get(f'oscs_{osc0}_freq')
+            log.warning('The current modulation configuration is not '
+                        'supported by pulsar. Cannot retrieve modulation '
+                        'frequency.')
+            return None
+        return g
 
     def get_divisor(self, chid, awg):
         '''

--- a/pycqed/measurement/waveform_control/pulsar.py
+++ b/pycqed/measurement/waveform_control/pulsar.py
@@ -598,7 +598,7 @@ class HDAWG8Pulsar:
             '{}_amplitude_scaling'.format(name),
             set_cmd=self._hdawg_setter(awg, id, 'amplitude_scaling'),
             get_cmd=self._hdawg_getter(awg, id, 'amplitude_scaling'),
-            vals=vals.Numbers(min_value=0.0, max_value=1.0),
+            vals=vals.Numbers(min_value=-1.0, max_value=1.0),
             initial_value=1.0)
         self.add_parameter('{}_distortion'.format(name),
                             label='{} distortion mode'.format(name),

--- a/pycqed/measurement/waveform_control/pulsar.py
+++ b/pycqed/measurement/waveform_control/pulsar.py
@@ -589,6 +589,12 @@ class HDAWG8Pulsar:
                             set_cmd=self._hdawg_setter(awg, id, 'amp'),
                             get_cmd=self._hdawg_getter(awg, id, 'amp'),
                             vals=vals.Numbers(0.01, 5.0))
+        self.add_parameter(
+            '{}_amplitude_scaling'.format(name),
+            set_cmd=self._hdawg_setter(awg, id, 'amplitude_scaling'),
+            get_cmd=self._hdawg_getter(awg, id, 'amplitude_scaling'),
+            vals=vals.Numbers(min_value=0.0, max_value=1.0),
+            initial_value=1.0)
         self.add_parameter('{}_distortion'.format(name),
                             label='{} distortion mode'.format(name),
                             initial_value='off',
@@ -647,6 +653,12 @@ class HDAWG8Pulsar:
                     obj.set('sigouts_{}_range'.format(int(id[2])-1), 2*val)
             else:
                 s = None
+        elif par == 'amplitude_scaling' and id[-1] != 'm':
+            awg = int((int(id[2:]) - 1) / 2)
+            output = (int(id[2:]) - 1) - 2 * awg
+            def s(val):
+                obj.set(f'awgs_{awg}_outputs_{output}_amplitude', val)
+                print(f'awgs_{awg}_outputs_{output}_amplitude: {val}')
         else:
             raise NotImplementedError('Unknown parameter {}'.format(par))
         return s
@@ -669,6 +681,11 @@ class HDAWG8Pulsar:
                             .format(int(id[2])-1))/2
             else:
                 return lambda: 1
+        elif par == 'amplitude_scaling' and id[-1] != 'm':
+            awg = int((int(id[2:]) - 1) / 2)
+            output = (int(id[2:]) - 1) - 2 * awg
+            def g():
+                return obj.get(f'awgs_{awg}_outputs_{output}_amplitude')
         else:
             raise NotImplementedError('Unknown parameter {}'.format(par))
         return g

--- a/pycqed/measurement/waveform_control/pulsar.py
+++ b/pycqed/measurement/waveform_control/pulsar.py
@@ -548,19 +548,6 @@ class HDAWG8Pulsar:
                                                vals.Lists(vals.Ints())),
                            parameter_class=ManualParameter)
 
-        for awg_nr in range(4):
-            param_name = f'{awg.name}_awgs_{awg_nr}_mod_freq'
-            self.add_parameter(param_name,
-                               unit='Hz',
-                               initial_value=None,
-                               set_cmd=self._hdawg_mod_setter(awg, awg_nr),
-                               get_cmd=self._hdawg_mod_getter(awg, awg_nr),
-                               )
-            # qcodes will not set the initial value if it is None, so we set it
-            # manually here to ensure that internal modulation gets switched off
-            # in the init.
-            self.set(f'{awg.name}_awgs_{awg_nr}_mod_freq', None)
-
         group = []
         for ch_nr in range(8):
             id = 'ch{}'.format(ch_nr + 1)
@@ -624,10 +611,20 @@ class HDAWG8Pulsar:
         self.add_parameter('{}_internal_modulation'.format(name), 
                            initial_value=False, vals=vals.Bool(),
                            parameter_class=ManualParameter)
-        cmd = self.parameters[
-            f'{awg.name}_awgs_{int((int(id[2:]) - 1) / 2)}_mod_freq']
-        self.add_parameter('{}_mod_freq'.format(name),
-                           unit='Hz', set_cmd=cmd, get_cmd=cmd)
+        if (int(id[2:]) - 1) % 2  == 0:  # first channel of a pair
+            awg_nr = int((int(id[2:]) - 1) / 2)
+            param_name = '{}_mod_freq'.format(name)
+            self.add_parameter(param_name,
+                               unit='Hz',
+                               initial_value=None,
+                               set_cmd=self._hdawg_mod_setter(awg, awg_nr),
+                               get_cmd=self._hdawg_mod_getter(awg, awg_nr),
+                               )
+            # qcodes will not set the initial value if it is None, so we set
+            # it manually here to ensure that internal modulation gets
+            # switched off in the init.
+            self.set(param_name, None)
+
 
     def _hdawg_create_marker_channel_parameters(self, id, name, awg):
         self.add_parameter('{}_id'.format(name), get_cmd=lambda _=id: _)

--- a/pycqed/measurement/waveform_control/pulsar.py
+++ b/pycqed/measurement/waveform_control/pulsar.py
@@ -586,7 +586,10 @@ class HDAWG8Pulsar:
             set_cmd=self._hdawg_setter(awg, id, 'amplitude_scaling'),
             get_cmd=self._hdawg_getter(awg, id, 'amplitude_scaling'),
             vals=vals.Numbers(min_value=-1.0, max_value=1.0),
-            initial_value=1.0)
+            initial_value=1.0,
+            docstring=f"Scales the AWG output of channel {name} with a given "
+                      f"factor between -1 and +1."
+        )
         self.add_parameter('{}_distortion'.format(name),
                             label='{} distortion mode'.format(name),
                             initial_value='off',
@@ -614,12 +617,18 @@ class HDAWG8Pulsar:
         if (int(id[2:]) - 1) % 2  == 0:  # first channel of a pair
             awg_nr = int((int(id[2:]) - 1) / 2)
             param_name = '{}_mod_freq'.format(name)
-            self.add_parameter(param_name,
-                               unit='Hz',
-                               initial_value=None,
-                               set_cmd=self._hdawg_mod_setter(awg, awg_nr),
-                               get_cmd=self._hdawg_mod_getter(awg, awg_nr),
-                               )
+            self.add_parameter(
+                param_name,
+                unit='Hz',
+                initial_value=None,
+                set_cmd=self._hdawg_mod_setter(awg, awg_nr),
+                get_cmd=self._hdawg_mod_getter(awg, awg_nr),
+                docstring=f"Carrier frequency of internal modulation for the "
+                          f"channel pair starting with {name}. Positive "
+                          f"(negative) sign corresponds to upper (lower) side "
+                          f"band. Setting the frequency to None disables "
+                          f"internal modulation."
+            )
             # qcodes will not set the initial value if it is None, so we set
             # it manually here to ensure that internal modulation gets
             # switched off in the init.
@@ -644,19 +653,21 @@ class HDAWG8Pulsar:
     @staticmethod
     def _hdawg_setter(obj, id, par):
         if par == 'offset':
-            if id[-1] != 'm':
+            if id[-1] != 'm':  # analog channel
                 def s(val):
                     obj.set('sigouts_{}_offset'.format(int(id[2])-1), val)
-            else:
+            else:  # marker channel (offset cannot be set)
                 s = None
         elif par == 'amp':
-            if id[-1] != 'm':
+            if id[-1] != 'm':  # analog channel
                 def s(val):
                     obj.set('sigouts_{}_range'.format(int(id[2])-1), 2*val)
-            else:
+            else:  # marker channel (scaling cannot be set)
                 s = None
         elif par == 'amplitude_scaling' and id[-1] != 'm':
+            # ch1/ch2 are on sub-awg 0, ch3/ch4 are on sub-awg 1, etc.
             awg = int((int(id[2:]) - 1) / 2)
+            # ch1/ch3/... are output 0, ch2/ch4/... are output 0,
             output = (int(id[2:]) - 1) - 2 * awg
             def s(val):
                 obj.set(f'awgs_{awg}_outputs_{output}_amplitude', val)
@@ -667,13 +678,13 @@ class HDAWG8Pulsar:
 
     def _hdawg_getter(self, obj, id, par):
         if par == 'offset':
-            if id[-1] != 'm':
+            if id[-1] != 'm':  # analog channel
                 def g():
                     return obj.get('sigouts_{}_offset'.format(int(id[2])-1))
-            else:
+            else:  # marker channel (offset always 0)
                 return lambda: 0
         elif par == 'amp':
-            if id[-1] != 'm':
+            if id[-1] != 'm':  # analog channel
                 def g():
                     if self._awgs_prequeried_state:
                         return obj.parameters['sigouts_{}_range' \
@@ -681,10 +692,12 @@ class HDAWG8Pulsar:
                     else:
                         return obj.get('sigouts_{}_range' \
                             .format(int(id[2])-1))/2
-            else:
+            else:  # marker channel
                 return lambda: 1
-        elif par == 'amplitude_scaling' and id[-1] != 'm':
+        elif par == 'amplitude_scaling' and id[-1] != 'm':  # analog channel
+            # ch1/ch2 are on sub-awg 0, ch3/ch4 are on sub-awg 1, etc.
             awg = int((int(id[2:]) - 1) / 2)
+            # ch1/ch3/... are output 0, ch2/ch4/... are output 0,
             output = (int(id[2:]) - 1) - 2 * awg
             def g():
                 return obj.get(f'awgs_{awg}_outputs_{output}_amplitude')
@@ -711,13 +724,31 @@ class HDAWG8Pulsar:
                 # first (second) channel of a pair.
                 sideband = np.sign(val)
                 freq = np.abs(val)
+                # see pycqed\instrument_drivers\physical_instruments\
+                #   ZurichInstruments\zi_parameter_files\node_doc_HDAWG8.json
+                # for description of the nodes used below.
+                # awg_nr: ch1/ch2 are on sub-awg 0, ch3/ch4 are on sub-awg 1,
+                # etc. Mode 1 (2) means that the AWG Output is multiplied with
+                # Sine Generator signal 0 (1) of this sub-awg
                 obj.set(f'awgs_{awg_nr}_outputs_0_modulation_mode', 1)
                 obj.set(f'awgs_{awg_nr}_outputs_1_modulation_mode', 2)
-                obj.set(f'sines_{awg_nr * 2}_oscselect', awg_nr * 4)
-                obj.set(f'sines_{awg_nr * 2 + 1}_oscselect', awg_nr * 4)
+                # For the oscillator, we can use any index, as long as the
+                # respective osc is not needed for anything else. Since we
+                # currently use oscs only here, the following index
+                # calculated from awg_nr can ensure that a unique osc is
+                # used for every channel pair for which we configure
+                # internal modulation.
+                osc_nr = awg_nr * 4
+                # set up the two sines of the channel pair with the same
+                # oscillator and with 90 phase shift
+                obj.set(f'sines_{awg_nr * 2}_oscselect', osc_nr)
+                obj.set(f'sines_{awg_nr * 2 + 1}_oscselect', osc_nr)
                 obj.set(f'sines_{awg_nr * 2}_phaseshift', 0)
+                # positive (negative) phase shift is needed for upper (
+                # lower) sideband
                 obj.set(f'sines_{awg_nr * 2 + 1}_phaseshift', sideband * 90)
-                obj.set(f'oscs_{awg_nr * 4}_freq', freq)
+                # configure the oscillator frequency
+                obj.set(f'oscs_{osc_nr}_freq', freq)
         return s
 
     @staticmethod
@@ -726,14 +757,22 @@ class HDAWG8Pulsar:
             m0 = obj.get(f'awgs_{awg_nr}_outputs_0_modulation_mode')
             m1 = obj.get(f'awgs_{awg_nr}_outputs_1_modulation_mode')
             if m0 == 0 and m1 == 0:
+                # If modulation mode is 0 for both outputs, internal
+                # modulation is switched off (indicated by a modulation
+                # frequency set to None).
                 return None
             elif m0 == 1 and m1 == 2:
+                # these calcuations invert the calculations in
+                # _hdawg_mod_setter, see therein for explaining comments
                 osc0 = obj.get(f'sines_{awg_nr * 2}_oscselect')
                 osc1 = obj.get(f'sines_{awg_nr * 2 + 1}_oscselect')
                 if osc0 == osc1:
                     sideband = np.sign(obj.get(
                         f'sines_{awg_nr * 2 + 1}_phaseshift'))
                     return sideband * obj.get(f'oscs_{osc0}_freq')
+            # If we have not returned a result at this point, the current
+            # AWG settings do not correspond to a configuration made by
+            # _hdawg_mod_setter.
             log.warning('The current modulation configuration is not '
                         'supported by pulsar. Cannot retrieve modulation '
                         'frequency.')

--- a/pycqed/measurement/waveform_control/pulsar.py
+++ b/pycqed/measurement/waveform_control/pulsar.py
@@ -698,7 +698,13 @@ class HDAWG8Pulsar:
                 obj.set(f'awgs_{awg_nr}_outputs_0_modulation_mode', 0)
                 obj.set(f'awgs_{awg_nr}_outputs_1_modulation_mode', 0)
             else:
-                # FIXME: implement SSB
+                # FIXME: this currently only works for real-valued baseband
+                # signals (zero Q component), and it assumes that the the I
+                # component gets programmed to both channels, see the case
+                # of mod_frequency=None in
+                # pulse_library.SSB_DRAG_pulse.chan_wf.
+                # In the future, we should extended this to support general
+                # IQ modulation and adapt the pulse library accordingly.
                 sideband = np.sign(val)
                 freq = np.abs(val)
                 obj.set(f'awgs_{awg_nr}_outputs_0_modulation_mode', 1)

--- a/pycqed/measurement/waveform_control/pulsar.py
+++ b/pycqed/measurement/waveform_control/pulsar.py
@@ -705,6 +705,8 @@ class HDAWG8Pulsar:
                 # pulse_library.SSB_DRAG_pulse.chan_wf.
                 # In the future, we should extended this to support general
                 # IQ modulation and adapt the pulse library accordingly.
+                # Also note that we here assume that the I (Q) channel is the
+                # first (second) channel of a pair.
                 sideband = np.sign(val)
                 freq = np.abs(val)
                 obj.set(f'awgs_{awg_nr}_outputs_0_modulation_mode', 1)

--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -98,6 +98,8 @@ class SSB_DRAG_pulse(pulse.Pulse):
                 phase=self.phase, phi_skew=self.phi_skew, alpha=self.alpha,
                 tval_phaseref=0 if self.phaselock else tc)
         else:
+            # Ignore the Q component and program the I component to both
+            # channels. See HDAWG8Pulsar._hdawg_mod_setter
             I_mod, Q_mod = gauss_env, gauss_env
 
         if channel == self.I_channel:

--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -92,10 +92,13 @@ class SSB_DRAG_pulse(pulse.Pulse):
                 tvals - tc < half)
         deriv_gauss_env = -self.motzoi * (tvals - tc) * gauss_env / self.sigma
 
-        I_mod, Q_mod = apply_modulation(
-            gauss_env, deriv_gauss_env, tvals, self.mod_frequency,
-            phase=self.phase, phi_skew=self.phi_skew, alpha=self.alpha,
-            tval_phaseref=0 if self.phaselock else tc)
+        if self.mod_frequency is not None:
+            I_mod, Q_mod = apply_modulation(
+                gauss_env, deriv_gauss_env, tvals, self.mod_frequency,
+                phase=self.phase, phi_skew=self.phi_skew, alpha=self.alpha,
+                tval_phaseref=0 if self.phaselock else tc)
+        else:
+            I_mod, Q_mod = gauss_env, gauss_env
 
         if channel == self.I_channel:
             return I_mod

--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -119,7 +119,7 @@ class SSB_DRAG_pulse(pulse.Pulse):
         if self.mod_frequency is not None:
             phase += 360 * self.phaselock * self.mod_frequency * (
                     self.algorithm_time() + self.nr_sigma * self.sigma / 2)
-        hashlist += [self.alpha, self.phi_skew, phase]
+            hashlist += [self.alpha, self.phi_skew, phase]
         return hashlist
 
 

--- a/pycqed/measurement/waveform_control/pulse_library.py
+++ b/pycqed/measurement/waveform_control/pulse_library.py
@@ -114,8 +114,9 @@ class SSB_DRAG_pulse(pulse.Pulse):
         hashlist += [channel == self.I_channel, self.amplitude, self.sigma]
         hashlist += [self.nr_sigma, self.motzoi, self.mod_frequency]
         phase = self.phase
-        phase += 360 * self.phaselock * self.mod_frequency * (
-                self.algorithm_time() + self.nr_sigma * self.sigma / 2)
+        if self.mod_frequency is not None:
+            phase += 360 * self.phaselock * self.mod_frequency * (
+                    self.algorithm_time() + self.nr_sigma * self.sigma / 2)
         hashlist += [self.alpha, self.phi_skew, phase]
         return hashlist
 


### PR DESCRIPTION
This pull request contains the measurement code that is currently used for flux line distortion characterization. It includes improvements in the FluxPulseScope, the new RabiFrequencySweep, and the required generic functionality in base classes & lower level modules. This includes i.a.:
- code for configuring a (very basic) internal modulation in the HDAWG (suitable for pi pulses without phase, without motzoi and without mixer calib)
- code for configuring output amplitude scaling in the HDAWG
- extension to ParallelLOSweepExperiment to set allowed LO freqs and perform the remaining sweep via an IF sweep with internal modulation
- extension to ParallelLOSweepExperiment to adapt drive amplitudes, readout frequencies, read-out-flux amplitudes, and DC flux biases during the frequency sweep
- extensions to RabiAnalysis and new RabiFrequencySweepAnalysis
- allow using pulse modifiers in calibration points
- various minor related changes, e.g. in the QuantumExperiment framework

Inviting @stephlazar to review.

FYI @antsr @nathlacroix 


