### PR TITLE
Update pyproject.toml to ship json files as part of package and add few gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,14 @@ data/*
 *.json
 *.dat
 .idea
+
+
+# Common Python Environment Names
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,4 @@ user = [
 where = ["./"]
 
 [tool.setuptools.package-data]
-pycqed = [
-    "utilities/WARNING.png",
-]
+pycqed = ["utilities/WARNING.png", "**/*.json"]


### PR DESCRIPTION
I found out that when you `pip install git+https://github.com/QudevETH/PycQED_py3` the json files in the repo are not installed and this breaks PycQED because some of them are needed at runtime. To make the json files ship alongside python sources, apparently one needs to explicitly specify them under [tool.setuptools.package-data] inside pyproject.toml. This PR makes the change so that all json files are shipped. One thing I am not sure is whether we want to include all json files or a subset of them, this is to be decided before merging this.

On the side, I added some common environment folder names like `.env`, `.venv` to .gitignore. This helps preventing accidentally committing virtual environment files that may be present in the local PycQED folder.